### PR TITLE
Improve eslint configuration, fix some warnings

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -88,7 +88,7 @@
     ],
     "*.{js,ts,tsx}": [
       "prettier --write",
-      "eslint --fix",
+      "eslint --fix --max-warnings=0",
       "react-scripts test --bail --findRelatedTests --watchAll=false"
     ]
   },

--- a/apps/client/src/components/Nav.test.js
+++ b/apps/client/src/components/Nav.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, fireEvent, cleanup, screen } from "../utils/test-utils";
+import { render, fireEvent, cleanup } from "../utils/test-utils";
 import Nav from "./Nav";
 import Form from "./Form";
 import { MemoryRouter } from "react-router-dom";

--- a/apps/client/src/routes.test.js
+++ b/apps/client/src/routes.test.js
@@ -1,5 +1,5 @@
-import { render, fireEvent, cleanup, screen } from "./utils/test-utils";
-import { getslug, geturl, routes } from "./routes";
+import { cleanup } from "./utils/test-utils";
+import { getslug, geturl } from "./routes";
 import slugify from "slugify";
 
 afterEach(cleanup);

--- a/apps/client/src/sttr_client/index.test.js
+++ b/apps/client/src/sttr_client/index.test.js
@@ -1,33 +1,33 @@
-import fs from "fs";
-import path from "path";
-import { promisify } from "util";
+// import fs from "fs";
+// import path from "path";
+// import { promisify } from "util";
 import getChecker from ".";
 
-const readdir = promisify(fs.readdir);
+// const readdir = promisify(fs.readdir);
 
-const buildDir = path.join(__dirname, "../../.build");
+// const buildDir = path.join(__dirname, "../../.build");
 
-const randbool = () => Math.random() >= 0.5;
-const getConfigFromFile = (filename) => {
-  const filepath = path.join(buildDir, filename);
-  const buffer = fs.readFileSync(filepath);
-  return JSON.parse(buffer.toString());
-};
+// const randbool = () => Math.random() >= 0.5;
+// const getConfigFromFile = (filename) => {
+//   const filepath = path.join(buildDir, filename);
+//   const buffer = fs.readFileSync(filepath);
+//   return JSON.parse(buffer.toString());
+// };
 
-const getCheckerFromFile = (filename) =>
-  getChecker(getConfigFromFile(filename));
+// const getCheckerFromFile = (filename) =>
+//   getChecker(getConfigFromFile(filename));
 
-const play = (checker) => {
-  let question = checker.next();
-  while (question) {
-    if (question.type === "boolean") {
-      question.setAnswer(randbool());
-    } else {
-      question.setAnswer("sure! why not.");
-    }
-    question = checker.next();
-  }
-};
+// const play = (checker) => {
+//   let question = checker.next();
+//   while (question) {
+//     if (question.type === "boolean") {
+//       question.setAnswer(randbool());
+//     } else {
+//       question.setAnswer("sure! why not.");
+//     }
+//     question = checker.next();
+//   }
+// };
 
 describe("sttr client", () => {
   test("getChecker", () => {

--- a/apps/client/src/sttr_client/models/checker-flolegal.test.js
+++ b/apps/client/src/sttr_client/models/checker-flolegal.test.js
@@ -4,15 +4,6 @@ import Question from "./question";
 import Rule from "./rule";
 import Decision from "./decision";
 
-const getQuestions = () => [
-  new Question({
-    id: "aaa",
-    type: "boolean",
-    text: "Do you live in a well-being area (welstandsgebied)?",
-    prio: 10,
-  }),
-];
-
 describe("STTR specific", () => {
   test('"-" and "no hit" support', () => {
     const q1 = new Question({

--- a/apps/graphql/package.json
+++ b/apps/graphql/package.json
@@ -58,7 +58,7 @@
   "lint-staged": {
     "*.{js}": [
       "prettier --write",
-      "eslint --fix",
+      "eslint --fix --max-warnings=0",
       "jest --bail --findRelatedTests"
     ]
   }


### PR DESCRIPTION
I found that the build server can fail when we run `react-scripts build`. This is because CRA does not allow for warnings during the build. I think this is a nice feature. This PR enables the same (kind of) behavior in de precommit hook.

Whats strange to me is why `--fix` did not fix these unused imports, but that's another question/issue.

I also fixed the warnings that were in the `apps/client`. The `apps/graphql` did not only have warnings but a lot of errors too. This should be fixed in a separate task.

A piece of code was uncommented because it's actually a good idea to implement that.

Please merge.