### PR TITLE
Fix: using Memo to stop rerendering Header+Footer

### DIFF
--- a/apps/client/src/components/Footer/Footer.js
+++ b/apps/client/src/components/Footer/Footer.js
@@ -8,7 +8,7 @@ import {
   Paragraph,
   Row,
 } from "@datapunt/asc-ui";
-import React from "react";
+import React, { memo } from "react";
 
 import { List, ListItem } from "../../atoms";
 import { FOOTER } from "../../utils/test-ids";
@@ -215,4 +215,4 @@ const Footer = () => (
   </CompactThemeProvider>
 );
 
-export default Footer;
+export default memo(Footer);

--- a/apps/client/src/components/Header.js
+++ b/apps/client/src/components/Header.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { memo } from "react";
 
 import { actions, categories } from "../config/matomo";
 import withTracking from "../hoc/withTracking";
@@ -41,4 +41,4 @@ export const Header = ({ matomoTrackEvent }) => {
   );
 };
 
-export default withTracking(Header);
+export default memo(withTracking(Header));


### PR DESCRIPTION
[If your function component renders the same result given the same props, you can wrap it in a call to `React.memo` for a performance boost in some cases by memoizing the result. This means that React will skip rendering the component, and reuse the last rendered result.](https://reactjs.org/docs/react-api.html#reactmemo)