### PR TITLE
Chappie2.0 Wrapper / Location styling + OLO FLow

### DIFF
--- a/apps/client/src/components/AddressLine.js
+++ b/apps/client/src/components/AddressLine.js
@@ -1,7 +1,12 @@
 import React from "react";
 
-export default ({ address: { streetName, houseNumberFull } }) => (
-  <strong>
-    {streetName} {houseNumberFull}
-  </strong>
-);
+export default ({ address: { streetName, houseNumberFull }, strong }) =>
+  strong ? (
+    <strong>
+      {streetName} {houseNumberFull}
+    </strong>
+  ) : (
+    <>
+      {streetName} {houseNumberFull}
+    </>
+  );

--- a/apps/client/src/components/Location/Location.js
+++ b/apps/client/src/components/Location/Location.js
@@ -9,7 +9,6 @@ import { CheckerContext, SessionContext } from "../../context";
 import withTopic from "../../hoc/withTopic";
 import { geturl, routes } from "../../routes";
 import { ADDRESS_PAGE } from "../../utils/test-ids";
-import AddressLine from "../AddressLine";
 import Error from "../Error";
 import Form from "../Form";
 import Nav from "../Nav";
@@ -106,33 +105,40 @@ const Location = ({ topic, finishedLocation, setFinishedLocation }) => {
   if (addressShown) {
     return (
       <Form onSubmit={handleAddressSubmit} data-testid={ADDRESS_PAGE}>
-        <Paragraph>
-          Over <AddressLine address={address} /> hebben we de volgende
-          informatie gevonden:
-        </Paragraph>
-
         <RegisterLookupSummary
           displayZoningPlans={!useSTTR}
           address={address}
+          setAddressShown={setAddressShown}
         />
 
-        <Paragraph>
-          {useSTTR
-            ? `We gebruiken deze informatie bij het invullen van de vergunningcheck. `
-            : `U hebt deze informatie nodig om de vergunningcheck te doen op het Omgevingsloket. `}
-        </Paragraph>
-        {topic.text?.addressPage && (
-          <Paragraph>{topic.text.addressPage}</Paragraph>
-        )}
-
         {!finishedLocation && (
-          <Nav
-            onGoToPrev={() => setAddressShown(false)}
-            nextText={!useSTTR ? "Naar het omgevingsloket" : "Naar de Vragen"}
-            formEnds={!useSTTR}
-            showPrev
-            showNext
-          />
+          <>
+            <Paragraph
+              gutterBottom={useSTTR && topic.text?.addressPage ? null : 0}
+            >
+              {useSTTR
+                ? // STTR Flow text (text we need to discuss because it's not in new design)
+                  `We gebruiken deze informatie bij het invullen van de
+                vergunningcheck.`
+                : // OLO Flow text
+                  ` U hebt deze informatie nodig om de vergunningcheck te doen op
+                het Omgevingsloket.`}
+            </Paragraph>
+
+            {/* Extra text about this activity (text that can be in both flows) */}
+            {/* This is also text we need to discuss because it's not in new design */}
+            {topic.text?.addressPage && (
+              <Paragraph gutterBottom={0}>{topic.text.addressPage}</Paragraph>
+            )}
+
+            <Nav
+              onGoToPrev={() => setAddressShown(false)}
+              nextText={!useSTTR ? "Naar het omgevingsloket" : "Naar de Vragen"}
+              formEnds={!useSTTR}
+              showPrev
+              showNext
+            />
+          </>
         )}
       </Form>
     );

--- a/apps/client/src/components/Location/Location.js
+++ b/apps/client/src/components/Location/Location.js
@@ -71,6 +71,8 @@ const Location = ({ topic, finishedLocation, setFinishedLocation }) => {
       } else {
         setAddressShown(true);
         if (checkerContext.checker) {
+          // Added rewindTo fix errrors on (hot) reloading
+          checkerContext.checker.rewindTo(0);
           checkerContext.checker.next();
         }
       }

--- a/apps/client/src/components/Location/Location.js
+++ b/apps/client/src/components/Location/Location.js
@@ -170,6 +170,7 @@ const Location = ({ topic, finishedLocation, setFinishedLocation }) => {
         />
         <Nav
           onGoToPrev={() => {
+            // @TODO: We need to give a warning or we need to store the checker data as well
             sessionContext.setSessionData([
               slug,
               {
@@ -179,6 +180,7 @@ const Location = ({ topic, finishedLocation, setFinishedLocation }) => {
             history.push(geturl(routes.intro, topic));
           }}
           showNext
+          showPrev
         />
       </Form>
     </>

--- a/apps/client/src/components/Questions.js
+++ b/apps/client/src/components/Questions.js
@@ -80,6 +80,8 @@ const Questions = ({
   };
 
   const onGoToQuestion = (questionIndex) => {
+    // Checker rewinding also needs to work when you already have a conlusion
+    setFinishedQuestions(false);
     // Go to the specific question in the stack
     checker.rewindTo(questionIndex);
     sessionContext.setSessionData([
@@ -90,17 +92,19 @@ const Questions = ({
     ]);
   };
 
+  // @TODO: Refactor this map function
   return checker.stack.map((q, i) => {
     if (q === checker.stack[questionIndex] && !finishedQuestions) {
       return (
         <StepByStepItem
           active
+          highlightActive
+          customSize
           heading={q.text}
-          onClick={() => onGoToQuestion(i)}
+          key={`question-${q.id}-${i}`}
         >
           <Question
             question={q}
-            key={`question-${q.id}-${i}`}
             onSubmit={onQuestionNext}
             onGoToPrev={onQuestionPrev}
             showPrev
@@ -119,11 +123,12 @@ const Questions = ({
       return (
         <StepByStepItem
           checked
+          customSize
           heading={q.text}
-          onClick={() => onGoToQuestion(i)}
+          key={`question-${q.id}-${i}`}
         >
           <Paragraph>
-            {removeQuotes(answer)}
+            {answer && removeQuotes(answer)}
             <Button
               style={{ marginLeft: 20 }}
               onClick={() => onGoToQuestion(i)}

--- a/apps/client/src/components/RegisterLookupSummary.js
+++ b/apps/client/src/components/RegisterLookupSummary.js
@@ -44,7 +44,7 @@ const RegisterLookupSummary = ({
       <Paragraph strong gutterBottom={0}>
         Beschermd stads- of dorpsgezicht:
       </Paragraph>
-      <Paragraph gutterBottom={0}>
+      <Paragraph gutterBottom={displayZoningPlans ? null : 0}>
         {cityScape
           ? `Ja. Het gebouw ligt in een beschermd stads- of dorpsgezicht.`
           : `Nee. Het gebouw ligt niet in een beschermd stads- of dorpsgezicht.`}

--- a/apps/client/src/components/RegisterLookupSummary.js
+++ b/apps/client/src/components/RegisterLookupSummary.js
@@ -1,12 +1,16 @@
-import { Paragraph } from "@datapunt/asc-ui";
+import { Button, Paragraph } from "@datapunt/asc-ui";
 import React from "react";
 
-import { List, ListItem } from "../atoms";
+import { ComponentWrapper, List, ListItem } from "../atoms";
 import { getRestrictionByTypeName } from "../utils";
 import { uniqueFilter } from "../utils";
-import { StyledRegisterLookupSummary } from "./RegisterLookupSummaryStyles";
+import AddressLine from "./AddressLine";
 
-const RegisterLookupSummary = ({ address, displayZoningPlans }) => {
+const RegisterLookupSummary = ({
+  address,
+  displayZoningPlans,
+  setAddressShown,
+}) => {
   const { restrictions, zoningPlans } = address;
   const monument = getRestrictionByTypeName(restrictions, "Monument")?.name;
   const cityScape = getRestrictionByTypeName(restrictions, "CityScape")?.name;
@@ -15,7 +19,21 @@ const RegisterLookupSummary = ({ address, displayZoningPlans }) => {
     .filter(uniqueFilter); // filter out duplicates (ie "Winkeldiversiteit Centrum" for 1012TK 1a)
 
   return (
-    <StyledRegisterLookupSummary>
+    <ComponentWrapper>
+      <Paragraph strong gutterBottom={0}>
+        Gekozen adres:
+      </Paragraph>
+      <Paragraph>
+        <AddressLine address={address} />
+        <Button
+          variant="textButton"
+          style={{ marginLeft: 12 }}
+          onClick={() => setAddressShown(false)}
+          type="button"
+        >
+          Wijzig
+        </Button>
+      </Paragraph>
       <Paragraph strong gutterBottom={0}>
         Monument:
       </Paragraph>
@@ -26,7 +44,7 @@ const RegisterLookupSummary = ({ address, displayZoningPlans }) => {
       <Paragraph strong gutterBottom={0}>
         Beschermd stads- of dorpsgezicht:
       </Paragraph>
-      <Paragraph gutterBottom={displayZoningPlans ? null : 0}>
+      <Paragraph gutterBottom={0}>
         {cityScape
           ? `Ja. Het gebouw ligt in een beschermd stads- of dorpsgezicht.`
           : `Nee. Het gebouw ligt niet in een beschermd stads- of dorpsgezicht.`}
@@ -55,7 +73,7 @@ const RegisterLookupSummary = ({ address, displayZoningPlans }) => {
           )}
         </>
       )}
-    </StyledRegisterLookupSummary>
+    </ComponentWrapper>
   );
 };
 

--- a/apps/client/src/components/RegisterLookupSummaryStyles.js
+++ b/apps/client/src/components/RegisterLookupSummaryStyles.js
@@ -1,8 +1,0 @@
-import { themeColor, themeSpacing } from "@datapunt/asc-ui";
-import styled from "styled-components";
-
-export const StyledRegisterLookupSummary = styled.div`
-  margin-bottom: ${themeSpacing(6)};
-  padding: ${themeSpacing(7)};
-  border: 1px solid ${themeColor("tint", "level3")};
-`;

--- a/apps/client/src/config/autofill.js
+++ b/apps/client/src/config/autofill.js
@@ -6,7 +6,7 @@ const getDataNeed = (checker) =>
 export const getDataNeedPageOrNext = (checker, autofillRoutes, routes) =>
   getDataNeed(checker)
     ? autofillRoutes[getDataNeed(checker)][0]
-    : routes.address;
+    : routes.wrapper;
 
 const strings = {
   NO_MONUMENT: "Geen monument",

--- a/apps/client/src/pages/IntroPage.js
+++ b/apps/client/src/pages/IntroPage.js
@@ -6,9 +6,8 @@ import Form from "../components/Form";
 import Layout from "../components/Layouts/DefaultLayout";
 import Loading from "../components/Loading";
 import Nav from "../components/Nav";
-import { getDataNeedPageOrNext } from "../config/autofill";
 import withChecker from "../hoc/withChecker";
-import { autofillRoutes, geturl, routes } from "../routes";
+import { geturl, routes } from "../routes";
 
 const IntroPage = ({ topic, checker }) => {
   const { text, intro } = topic;
@@ -22,12 +21,7 @@ const IntroPage = ({ topic, checker }) => {
       <Suspense fallback={<Loading />}>
         <Intro />
       </Suspense>
-      <Form
-        action={geturl(
-          getDataNeedPageOrNext(checker, autofillRoutes, routes),
-          topic
-        )}
-      >
+      <Form action={geturl(routes.wrapper, topic)}>
         <Nav showNext />
       </Form>
 

--- a/apps/client/src/pages/WrapperPage.js
+++ b/apps/client/src/pages/WrapperPage.js
@@ -9,6 +9,7 @@ import {
   StepByStepItem,
   StepByStepNavigation,
 } from "../components/StepByStepNavigation";
+import withChecker from "../hoc/withChecker";
 
 const WrapperPage = () => {
   const [finishedLocation, setFinishedLocation] = useState(false);
@@ -40,10 +41,11 @@ const WrapperPage = () => {
         {/* {isSTTR && } */}
         <StepByStepItem
           checked={finishedQuestions}
+          done={finishedLocation}
           heading="Vragen"
           largeCircle
         />
-        {!finishedQuestions && finishedLocation && (
+        {finishedLocation && (
           <Questions
             finishedQuestions={finishedQuestions}
             setFinishedLocation={setFinishedLocation}
@@ -61,4 +63,5 @@ const WrapperPage = () => {
     </Layout>
   );
 };
-export default WrapperPage;
+// Added withChecker() to fix errors on (hot) reloading
+export default withChecker(WrapperPage);

--- a/apps/client/src/pages/WrapperPage.js
+++ b/apps/client/src/pages/WrapperPage.js
@@ -35,6 +35,9 @@ const WrapperPage = () => {
             setFinishedLocation={setFinishedLocation}
           />
         </StepByStepItem>
+
+        {/* All the components below only needs to be shown in STTR flow: */}
+        {/* {isSTTR && } */}
         <StepByStepItem
           checked={finishedQuestions}
           heading="Vragen"


### PR DESCRIPTION
#### How it looks now when active:
![image](https://user-images.githubusercontent.com/7781865/88566971-1c9c3780-d037-11ea-89b9-00e818e57a1b.png)

#### How it looks now when inactive:
![image](https://user-images.githubusercontent.com/7781865/88567253-87e60980-d037-11ea-8005-c8f57fd4f7df.png)

----

_Text as discussed with design._

----

## Styling updates:
- Location Component copy
- Correct circle size and color to StepByStepItems
- Display correct sections
- Able to change question answers

---

### Things that need to be done in the refactor branch:
- Navigating from WrapperPage to Intro page: We need to give a warning or we need to store the checker data as well
- Detecting inside WrapperPage if the flow is either STTR or OLO, because some components only needs to be shown in STTR flow

### Things that need to be discussed with design:
- STTR Flow text (text we need to discuss because it's not in new design)
- Extra text about this activity (text that can be in both flows)

## All those things can be done in separate PR's

### Things that need to change in ASC-UI (PR's are open):
- Radio needs a white background, see https://github.com/Amsterdam/amsterdam-styled-components/pull/876
- Select with the `disabled` prop has an issue with background-color, see
 https://github.com/Amsterdam/amsterdam-styled-components/pull/875
