### PR TITLE
Feature: Updated layout (mobile, Location and OLO)

### DIFF
--- a/apps/client/src/components/HeaderStyles.js
+++ b/apps/client/src/components/HeaderStyles.js
@@ -7,16 +7,16 @@ import { focusOutlineStyle } from "../utils/themeUtils";
 
 export const StyledHeader = styled(Header)`
   max-width: 960px;
-  padding: 0 ${themeSpacing(5)};
+  padding: 0 ${themeSpacing(4)};
 
+  @media ${breakpoint("min-width", "tabletS")} {
+    padding: 0 ${themeSpacing(5)};
+  }
   @media ${breakpoint("min-width", "tabletM")} {
     padding: 0 ${themeSpacing(6)};
   }
   @media ${breakpoint("min-width", "laptop")} {
     padding: 0 ${themeSpacing(8)};
-  }
-  @media ${breakpoint("min-width", "laptopM")} {
-    padding: 0 ${themeSpacing(11)};
   }
 `;
 

--- a/apps/client/src/components/Layouts/BaseLayout.tsx
+++ b/apps/client/src/components/Layouts/BaseLayout.tsx
@@ -26,7 +26,7 @@ function BaseLayout({ children, checker, heading }: BaseLayoutProps) {
       </Helmet>
       <Header />
       <ContentContainer>
-        <Row>
+        <Row hasMargin={false}>
           <Column
             wrap
             span={{

--- a/apps/client/src/components/Layouts/BaseLayoutStyles.js
+++ b/apps/client/src/components/Layouts/BaseLayoutStyles.js
@@ -1,11 +1,11 @@
-import { breakpoint, themeSpacing } from "@datapunt/asc-ui";
+import { breakpoint, themeColor, themeSpacing } from "@datapunt/asc-ui";
 import styled from "styled-components";
 
 export const Container = styled.div`
   max-width: 1400px;
   width: 100%;
   margin: 0 auto;
-  background-color: white;
+  background-color: ${themeColor("tint", "level1")};
   overflow: hidden;
 `;
 
@@ -13,13 +13,21 @@ export const ContentContainer = styled.div`
   max-width: 960px;
   width: 100%;
   margin: 0 auto;
-  background-color: white;
+  padding-left: ${themeSpacing(4)};
+  padding-right: ${themeSpacing(4)};
+  background-color: ${themeColor("tint", "level1")};
 
-  @media screen and ${breakpoint("min-width", "tabletS")} and
-  ${breakpoint("max-width", "laptop")}
-  {
-    padding-left: ${themeSpacing(4)};
-    padding-right: ${themeSpacing(4)};
+  @media screen and ${breakpoint("min-width", "tabletS")} {
+    padding-left: ${themeSpacing(9)};
+    padding-right: ${themeSpacing(9)};
+  }
+  @media screen and ${breakpoint("min-width", "tabletM")} {
+    padding-left: ${themeSpacing(10)};
+    padding-right: ${themeSpacing(10)};
+  }
+  @media screen and ${breakpoint("min-width", "laptop")} {
+    padding-left: ${themeSpacing(8)};
+    padding-right: ${themeSpacing(8)};
   }
 `;
 

--- a/apps/client/src/components/Location/Location.js
+++ b/apps/client/src/components/Location/Location.js
@@ -123,23 +123,12 @@ const Location = ({ topic }) => {
 
         {!finishedLocation && (
           <>
-            <Paragraph
-              gutterBottom={useSTTR && topic.text?.addressPage ? null : 0}
-            >
-              {useSTTR
-                ? // STTR Flow text (text we need to discuss because it's not in new design)
-                  `We gebruiken deze informatie bij het invullen van de
-                vergunningcheck.`
-                : // OLO Flow text
-                  ` U hebt deze informatie nodig om de vergunningcheck te doen op
+            <Paragraph gutterBottom={useSTTR ? null : 0}>
+              {/* OLO Flow text */}
+              {!useSTTR &&
+                ` U hebt deze informatie nodig om de vergunningcheck te doen op
                 het Omgevingsloket.`}
             </Paragraph>
-
-            {/* Extra text about this activity (text that can be in both flows) */}
-            {/* This is also text we need to discuss because it's not in new design */}
-            {topic.text?.addressPage && (
-              <Paragraph gutterBottom={0}>{topic.text.addressPage}</Paragraph>
-            )}
 
             <Nav
               onGoToPrev={() =>

--- a/apps/client/src/components/RegisterLookupSummary.js
+++ b/apps/client/src/components/RegisterLookupSummary.js
@@ -10,7 +10,7 @@ import AddressLine from "./AddressLine";
 const RegisterLookupSummary = ({
   address,
   displayZoningPlans,
-  topic: { slug },
+  topic: { slug, sttrFile },
 }) => {
   const sessionContext = useContext(SessionContext);
   const { restrictions, zoningPlans } = address;
@@ -21,11 +21,8 @@ const RegisterLookupSummary = ({
     .filter(uniqueFilter); // filter out duplicates (ie "Winkeldiversiteit Centrum" for 1012TK 1a)
 
   return (
-    <ComponentWrapper>
-      <Paragraph strong gutterBottom={0}>
-        Gekozen adres:
-      </Paragraph>
-      <Paragraph>
+    <ComponentWrapper marginBottom={sttrFile ? "0" : null}>
+      <Paragraph gutterBottom={16}>
         <AddressLine address={address} />
         <Button
           variant="textButton"
@@ -43,20 +40,25 @@ const RegisterLookupSummary = ({
           Wijzig
         </Button>
       </Paragraph>
+      <Paragraph gutterBottom={16}>
+        Over dit adres hebben we de volgende gegevens gevonden:
+      </Paragraph>
       <Paragraph strong gutterBottom={0}>
         Monument:
       </Paragraph>
-      <Paragraph>
-        {monument ? `Ja. ${monument}.` : "Nee. Geen monument."}
+      <Paragraph gutterBottom={16}>
+        {monument
+          ? `Het gebouw is een ${monument.toLowerCase()}.`
+          : "Het gebouw is geen monument."}
       </Paragraph>
 
       <Paragraph strong gutterBottom={0}>
         Beschermd stads- of dorpsgezicht:
       </Paragraph>
-      <Paragraph gutterBottom={displayZoningPlans ? null : 0}>
+      <Paragraph gutterBottom={displayZoningPlans ? 16 : 0}>
         {cityScape
-          ? `Ja. Het gebouw ligt in een beschermd stads- of dorpsgezicht.`
-          : `Nee. Het gebouw ligt niet in een beschermd stads- of dorpsgezicht.`}
+          ? `Het gebouw ligt in een beschermd stads- of dorpsgezicht.`
+          : `Het gebouw ligt niet in een beschermd stads- of dorpsgezicht.`}
       </Paragraph>
 
       {displayZoningPlans && (
@@ -65,7 +67,7 @@ const RegisterLookupSummary = ({
             Bestemmingsplannen:
           </Paragraph>
           {zoningPlanNames.length === 0 ? (
-            <Paragraph>Geen bestemmingsplan</Paragraph>
+            <Paragraph>Geen bestemmingsplannen</Paragraph>
           ) : (
             <List
               variant="bullet"

--- a/apps/client/src/components/StepByStepNavigation/StepByStepItemStyle.ts
+++ b/apps/client/src/components/StepByStepNavigation/StepByStepItemStyle.ts
@@ -36,9 +36,7 @@ export default styled.div<Props>`
   position: relative;
   display: flex;
   height: 100%;
-  padding-top: ${themeSpacing(4)};
-  padding-bottom: ${themeSpacing(5)};
-  padding-right: ${themeSpacing(4)};
+  padding: ${themeSpacing(4, 4, 4, 0)};
   text-decoration: none;
   cursor: initial;
 

--- a/apps/client/src/components/StepByStepNavigation/StepByStepNavigationStyle.ts
+++ b/apps/client/src/components/StepByStepNavigation/StepByStepNavigationStyle.ts
@@ -10,13 +10,8 @@ export type Props = {
 };
 
 export default styled.div<Props>`
-  ${StepByStepItemStyle} {
-    &:last-child {
-      padding-bottom: 0;
-
-      ${CircleWrapperStyle}:after {
-        content: none;
-      }
-    }
+  /* Remove the line (going downwards) only from the last Item */
+  ${StepByStepItemStyle}:last-child ${CircleWrapperStyle}:after {
+    content: none;
   }
 `;

--- a/apps/client/src/config/index.ts
+++ b/apps/client/src/config/index.ts
@@ -38,6 +38,7 @@ const topics: Topic[] = [
     text: {
       heading: "Vergunningcheck dakkapel plaatsen",
       locationIntro: "Voer het adres in waar u de dakkapel wilt gaan plaatsen",
+      // @TODO: The text `addressPage` is now unused > What to do with this text?
       addressPage:
         "Gaat u meer dan 1 dakkapel plaatsen? Doe dan per dakkapel de vergunningcheck.",
     },
@@ -49,6 +50,7 @@ const topics: Topic[] = [
     text: {
       heading: "Vergunningcheck dakraam plaatsen",
       locationIntro: "Voer het adres in waar u het dakraam wilt gaan plaatsen",
+      // @TODO: The text `addressPage` is now unused > What to do with this text?
       addressPage:
         "Gaat u meer dan 1 dakraam plaatsen? Doe dan per dakraam de vergunningcheck.",
     },

--- a/apps/client/src/pages/WrapperPage.js
+++ b/apps/client/src/pages/WrapperPage.js
@@ -1,6 +1,7 @@
 import React, { useContext } from "react";
 import { Helmet } from "react-helmet";
 
+import { ComponentWrapper } from "../atoms";
 import Conclusion from "../components/Conclusion";
 import DebugDecisionTable from "../components/DebugDecisionTable";
 import Layout from "../components/Layouts/DefaultLayout";
@@ -23,48 +24,57 @@ const WrapperPage = ({ checker, topic }) => {
       <Helmet>
         <title>Wrapper Page</title>
       </Helmet>
-      <StepByStepNavigation
-        customSize
-        disabledTextColor="inherit"
-        doneTextColor="inherit"
-        highlightActive
-      >
-        <StepByStepItem
-          active={!finishedLocation}
-          checked={finishedLocation}
-          heading="Adres gegevens"
-          largeCircle
-        >
-          <Location />
-        </StepByStepItem>
 
-        {/* Only show questions and conclusion in STTR-flow */}
+      <ComponentWrapper>
+        {/* STTR-flow with the StepByStepNavigation */}
         {sttrFile && (
-          <>
+          <StepByStepNavigation
+            customSize
+            disabledTextColor="inherit"
+            doneTextColor="inherit"
+            highlightActive
+          >
             <StepByStepItem
-              checked={finishedQuestions}
-              customSize
-              done={finishedLocation}
-              heading="Vragen"
-              highlightActive
-              largeCircle
-            />
-            {finishedLocation && <Questions checker={checker} topic={topic} />}
-            <StepByStepItem
-              active={finishedLocation && finishedQuestions}
-              checked={finishedLocation && finishedQuestions}
-              customSize
-              heading="Conclusie"
-              highlightActive
+              active={!finishedLocation}
+              checked={finishedLocation}
+              heading="Adres gegevens"
               largeCircle
             >
-              {finishedQuestions && (
-                <Conclusion checker={checker} topic={topic} />
-              )}
+              <Location />
             </StepByStepItem>
-          </>
+
+            <>
+              <StepByStepItem
+                checked={finishedQuestions}
+                customSize
+                done={finishedLocation}
+                heading="Vragen"
+                highlightActive
+                largeCircle
+              />
+              {finishedLocation && (
+                <Questions checker={checker} topic={topic} />
+              )}
+              <StepByStepItem
+                active={finishedLocation && finishedQuestions}
+                checked={finishedLocation && finishedQuestions}
+                customSize
+                heading="Conclusie"
+                highlightActive
+                largeCircle
+              >
+                {finishedQuestions && (
+                  <Conclusion checker={checker} topic={topic} />
+                )}
+              </StepByStepItem>
+            </>
+          </StepByStepNavigation>
         )}
-      </StepByStepNavigation>
+
+        {/* OLO-flow only needs the Location component */}
+        {!sttrFile && <Location />}
+      </ComponentWrapper>
+
       <DebugDecisionTable {...{ topic, checker }} />
     </Layout>
   );


### PR DESCRIPTION
### Changes:
- I removed the `StepByStepNavigation` from the OLO flow since there is only one item.
- Mobile layout is now conform our design (16px padding instead of 20px) > more space! 👍 
- Changed `Location` texts (see below) and removed unused `Location` texts (added comment "where to place this text?")
- Minor padding styling changes in `StepByStepNavigation` and `StepByStepItem` 
- Wrapped `StepByStepNavigation` in a `ComponentWrapper` (nothing is changed within the `ComponentWrapper` itself)

### Location result:
<image src="https://user-images.githubusercontent.com/7781865/88810462-a7a33c00-d1b5-11ea-86f5-331c8c3b2403.png" width="75%" />

### Mobile result:
<image src="https://user-images.githubusercontent.com/7781865/88811327-b2120580-d1b6-11ea-9547-17249211a845.png" width="50%" />
