### PR TITLE
Bug: Helmet no longer supports `true` as a middleware option.

### DIFF
--- a/apps/graphql/src/secure.js
+++ b/apps/graphql/src/secure.js
@@ -31,7 +31,7 @@ module.exports = (app) => {
         maxAge: 0, // 604800 is used on parent site
         reportUri: "https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct",
       },
-      permittedCrossDomainPolicies: true,
+      permittedCrossDomainPolicies: "all",
       referrerPolicy: { policy: "no-referrer" },
     })
   );


### PR DESCRIPTION
`options.permittedPolicies` is a string that must be "none", "master-only", "by-content-type", or "all". It defaults to "none".