### PR TITLE
Feature: Updated NGINX config to fix bugs with Sentry and Usabilla

### DIFF
--- a/ci/nginx-deployed.conf
+++ b/ci/nginx-deployed.conf
@@ -32,7 +32,7 @@ server {
         root  /usr/share/nginx/html/;
         try_files $uri /index.html =404;
 
-        add_header Content-Security-Policy "default-src 'self'; script-src 'unsafe-inline' 'self' https://sentry.data.amsterdam.nl/ https://analytics.data.amsterdam.nl https://w.usabilla.com https://api.usabilla.com; img-src 'self' https://sttr-files.flolegal.app https://analytics.data.amsterdam.nl https://d6tizftlrpuof.cloudfront.net https://w.usabilla.com; style-src 'self' 'unsafe-inline' https://d6tizftlrpuof.cloudfront.net; connect-src 'self' https://api.usabilla.com";
+        add_header Content-Security-Policy "default-src 'self'; script-src 'unsafe-inline' 'self' https://*.data.amsterdam.nl https://d6tizftlrpuof.cloudfront.net https://*.usabilla.com; img-src 'self' https://*.data.amsterdam.nl https://*.flolegal.app https://d6tizftlrpuof.cloudfront.net https://*.usabilla.com; style-src 'self' 'unsafe-inline' https://d6tizftlrpuof.cloudfront.net; connect-src 'self' https://*.data.amsterdam.nl https://*.usabilla.com";
         add_header Feature-Policy "document-write 'self'; geolocation 'none'; camera 'none'; speaker 'none';";
         add_header Referrer-Policy no-referrer;
         add_header X-Content-Type-Options nosniff;


### PR DESCRIPTION
## Warning: merging into `release` branch so we can directly check if this works

IF this fails, we must remove the `https://` prefix, so it will become:

```
add_header Content-Security-Policy "default-src 'self'; script-src 'unsafe-inline' 'self' *.data.amsterdam.nl https://d6tizftlrpuof.cloudfront.net *.usabilla.com; img-src 'self' *.data.amsterdam.nl *.flolegal.app https://d6tizftlrpuof.cloudfront.net *.usabilla.com; style-src 'self' 'unsafe-inline' https://d6tizftlrpuof.cloudfront.net; connect-src 'self' *.data.amsterdam.nl *.usabilla.com";
```

See:
1. https://gist.github.com/corburn/9ad9d07535d59b478159 `add_header Content-Security-Policy-Report-Only`
2. https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP `Example 5`