### PR TITLE
DRAFT: Feature: Skip through answered questions onQuestionNext

### DIFF
--- a/apps/client/src/components/Questions.js
+++ b/apps/client/src/components/Questions.js
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { useCallback, useContext, useEffect, useState } from "react";
 
 import { SessionContext } from "../context";
 import Question, { booleanOptions } from "./Question";
@@ -15,7 +15,94 @@ const Questions = ({
   isFinished,
 }) => {
   const sessionContext = useContext(SessionContext);
+  const [skipAnsweredQuestions, setSkipAnsweredQuestions] = useState(false);
   const { questionIndex } = sessionContext[slug];
+
+  const goToConclusion = useCallback(() => {
+    setActiveState("conclusion");
+    setFinishedState(["questions", "conslusion"], true);
+  }, [setActiveState, setFinishedState]);
+
+  const onQuestionNext = useCallback(() => {
+    const question = checker.stack[questionIndex];
+
+    if (checker.needContactExit(question)) {
+      // Go directly to "Contact Conclusion" and skip other questions
+      goToConclusion();
+    } else {
+      // Load the next question or go to the "Conclusion"
+      if (checker.stack.length - 1 === questionIndex) {
+        // If the (stack length - 1) is equal to the questionIndex, we want to load a new question
+        const next = checker.next();
+
+        if (next) {
+          // Go to next question
+          goToQuestion("next");
+          // Turn skipping answered questions off
+          setSkipAnsweredQuestions(true);
+        } else {
+          // Go to the "Conclusion"
+          goToConclusion();
+        }
+      } else {
+        // In this case, the user is changing a previously answered question and we don't want to load a new question
+        goToQuestion("next");
+        // Turn skipping answered questions off
+        setSkipAnsweredQuestions(true);
+      }
+    }
+  }, [checker, questionIndex, goToQuestion, goToConclusion]);
+
+  const onQuestionPrev = () => {
+    // Load the previous question or go to "Location"
+    if (checker.stack.length > 1) {
+      // Store the new questionIndex in the session
+      goToQuestion("prev");
+    }
+    if (questionIndex === 0) {
+      setActiveState("locationResult");
+      setFinishedState("locationResult", false);
+      // This prevents to uncheck the Item that holds "questions" (when all questions are answered)
+      if (!isFinished("questions")) {
+        setFinishedState("questions", false);
+      }
+    }
+  };
+
+  useEffect(() => {
+    if (skipAnsweredQuestions) {
+      // Turn skipping answered questions off
+      setSkipAnsweredQuestions(false);
+
+      // Loop through questions
+      checker.stack.forEach((q) => {
+        // @TODO: refactor this into isQuestionAnswered() because this code is used often
+        const booleanAnswers =
+          !q.options && booleanOptions.find((o) => o.value === q.answer);
+        const userAnswer = q.options ? q.answer : booleanAnswers?.label;
+        const isCurrentQuestion =
+          q === checker.stack[questionIndex] && isActive("questions");
+
+        // Skip question if already answered
+        if (isCurrentQuestion && userAnswer) {
+          onQuestionNext();
+        }
+      });
+    }
+  }, [checker, isActive, questionIndex, onQuestionNext, skipAnsweredQuestions]);
+
+  const onGoToQuestion = useCallback(
+    (questionId) => {
+      // Checker rewinding also needs to work when you already have a conlusion
+      // Go to the specific question in the stack
+      setActiveState("questions");
+      setFinishedState(["conclusion", "questions"], false);
+      setFinishedState("locationResult", true);
+
+      goToQuestion(questionId);
+    },
+    [goToQuestion, setActiveState, setFinishedState]
+  );
 
   // Check which questions are causing the need for a permit
   // @TODO: We can refactor this and move to checker.js
@@ -64,63 +151,6 @@ const Questions = ({
         answers: checker.getQuestionAnswers(),
       },
     ]);
-  };
-
-  const goToConclusion = () => {
-    setActiveState("conclusion");
-    setFinishedState(["questions", "conslusion"], true);
-  };
-
-  const onQuestionNext = () => {
-    const question = checker.stack[questionIndex];
-
-    if (checker.needContactExit(question)) {
-      // Go directly to "Contact Conclusion" and skip other questions
-      goToConclusion();
-    } else {
-      // Load the next question or go to the "Conclusion"
-      if (checker.stack.length - 1 === questionIndex) {
-        // If the (stack length - 1) is equal to the questionIndex, we want to load a new question
-        const next = checker.next();
-
-        if (next) {
-          // Go to next question
-          goToQuestion("next");
-        } else {
-          // Go to the "Conclusion"
-          goToConclusion();
-        }
-      } else {
-        // In this case, the user is changing a previously answered question and we don't want to load a new question
-        goToQuestion("next");
-      }
-    }
-  };
-
-  const onQuestionPrev = () => {
-    // Load the previous question or go to "Location"
-    if (checker.stack.length > 1) {
-      // Store the new questionIndex in the session
-      goToQuestion("prev");
-    }
-    if (questionIndex === 0) {
-      setActiveState("locationResult");
-      setFinishedState("locationResult", false);
-      // This prevents to uncheck the Item that holds "questions" (when all questions are answered)
-      if (!isFinished("questions")) {
-        setFinishedState("questions", false);
-      }
-    }
-  };
-
-  const onGoToQuestion = (questionId) => {
-    // Checker rewinding also needs to work when you already have a conlusion
-    // Go to the specific question in the stack
-    setActiveState("questions");
-    setFinishedState(["conclusion", "questions"], false);
-    setFinishedState("locationResult", true);
-
-    goToQuestion(questionId);
   };
 
   if (checker.stack.length === 0) {


### PR DESCRIPTION
## Feature request from Annick: "go to next question" should skip already answered questions by the user

### Skipping answered questions works very nice, but has the following challenges:
- Now we need a solution to force the window to go to the conclusion(eg: "scroll") otherwise the user is on the top but the conclusion is in the bottom
- How does "go to previous question" work? If this is going one question up then it's inconsistent with "go to next question", because that skips (maybe the dynamic labels (Next question / Go to conclusion) will help