### PR TITLE
Feature: Show and skip already answered questions 

### DIFF
--- a/apps/client/src/components/QuestionAnswer.tsx
+++ b/apps/client/src/components/QuestionAnswer.tsx
@@ -6,18 +6,19 @@ import { removeQuotes } from "../utils";
 import PermitAlert from "./PermitAlert";
 
 type QuestionAnswerProps = {
+  hideEditButton?: Boolean;
   questionNeedsPermit: Boolean;
   userAnswer: string;
 };
 
 const QuestionAnswer: React.FC<
   QuestionAnswerProps & React.HTMLAttributes<HTMLElement>
-> = ({ onClick, questionNeedsPermit, userAnswer }) => {
+> = ({ hideEditButton, questionNeedsPermit, onClick, userAnswer }) => {
   return (
     <>
       <Paragraph gutterBottom={0}>
         {removeQuotes(userAnswer)}
-        <EditButton {...{ onClick }} />
+        {!hideEditButton && <EditButton {...{ onClick }} />}
       </Paragraph>
       {questionNeedsPermit && <PermitAlert />}
     </>

--- a/apps/client/src/components/Questions.js
+++ b/apps/client/src/components/Questions.js
@@ -219,10 +219,14 @@ const Questions = ({
           !q.options && booleanOptions.find((o) => o.value === q.answer);
         const userAnswer = q.options ? q.answer : booleanAnswers?.label;
 
+        // Skip unanswered questions
+        if (!userAnswer) return null;
+
         // Check if currect question is causing a permit requirement
         const questionNeedsPermit = !!permitsPerQuestion[i];
 
-        if (!userAnswer) return null;
+        // Get new index
+        const index = i + checker.stack.length;
 
         return (
           <StepByStepItem
@@ -230,12 +234,11 @@ const Questions = ({
             checked
             customSize
             heading={q.text}
-            key={`question-${q.id}-${i}`}
-            // style={isCurrentQuestion ? activeStyle : {}}
+            key={`question-${q.id}-${index}`}
           >
             <QuestionAnswer
-              hideEditButton
-              onClick={() => onGoToQuestion(i)}
+              hideEditButton={!checker.isConclusive()}
+              onClick={() => onGoToQuestion(index)}
               {...{ questionNeedsPermit, userAnswer }}
             />
           </StepByStepItem>

--- a/apps/client/src/components/Questions.js
+++ b/apps/client/src/components/Questions.js
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { useCallback, useContext, useEffect, useState } from "react";
 
 import { SessionContext } from "../context";
 import Question, { booleanOptions } from "./Question";
@@ -15,7 +15,94 @@ const Questions = ({
   isFinished,
 }) => {
   const sessionContext = useContext(SessionContext);
+  const [skipAnsweredQuestions, setSkipAnsweredQuestions] = useState(false);
   const { questionIndex } = sessionContext[slug];
+
+  const goToConclusion = useCallback(() => {
+    setActiveState("conclusion");
+    setFinishedState(["questions", "conslusion"], true);
+  }, [setActiveState, setFinishedState]);
+
+  const onQuestionNext = useCallback(() => {
+    const question = checker.stack[questionIndex];
+
+    if (checker.needContactExit(question)) {
+      // Go directly to "Contact Conclusion" and skip other questions
+      goToConclusion();
+    } else {
+      // Load the next question or go to the "Conclusion"
+      if (checker.stack.length - 1 === questionIndex) {
+        // If the (stack length - 1) is equal to the questionIndex, we want to load a new question
+        const next = checker.next();
+
+        if (next) {
+          // Go to next question
+          goToQuestion("next");
+          // Turn skipping answered questions off
+          setSkipAnsweredQuestions(true);
+        } else {
+          // Go to the "Conclusion"
+          goToConclusion();
+        }
+      } else {
+        // In this case, the user is changing a previously answered question and we don't want to load a new question
+        goToQuestion("next");
+        // Turn skipping answered questions off
+        setSkipAnsweredQuestions(true);
+      }
+    }
+  }, [checker, questionIndex, goToQuestion, goToConclusion]);
+
+  const onQuestionPrev = () => {
+    // Load the previous question or go to "Location"
+    if (checker.stack.length > 1) {
+      // Store the new questionIndex in the session
+      goToQuestion("prev");
+    }
+    if (questionIndex === 0) {
+      setActiveState("locationResult");
+      setFinishedState("locationResult", false);
+      // This prevents to uncheck the Item that holds "questions" (when all questions are answered)
+      if (!isFinished("questions")) {
+        setFinishedState("questions", false);
+      }
+    }
+  };
+
+  useEffect(() => {
+    if (skipAnsweredQuestions) {
+      // Turn skipping answered questions off
+      setSkipAnsweredQuestions(false);
+
+      // Loop through questions
+      checker.stack.forEach((q) => {
+        // @TODO: refactor this into isQuestionAnswered() because this code is used often
+        const booleanAnswers =
+          !q.options && booleanOptions.find((o) => o.value === q.answer);
+        const userAnswer = q.options ? q.answer : booleanAnswers?.label;
+        const isCurrentQuestion =
+          q === checker.stack[questionIndex] && isActive("questions");
+
+        // Skip question if already answered
+        if (isCurrentQuestion && userAnswer) {
+          onQuestionNext();
+        }
+      });
+    }
+  }, [checker, isActive, questionIndex, onQuestionNext, skipAnsweredQuestions]);
+
+  const onGoToQuestion = useCallback(
+    (questionId) => {
+      // Checker rewinding also needs to work when you already have a conlusion
+      // Go to the specific question in the stack
+      setActiveState("questions");
+      setFinishedState(["conclusion", "questions"], false);
+      setFinishedState("locationResult", true);
+
+      goToQuestion(questionId);
+    },
+    [goToQuestion, setActiveState, setFinishedState]
+  );
 
   // Check which questions are causing the need for a permit
   // @TODO: We can refactor this and move to checker.js
@@ -64,63 +151,6 @@ const Questions = ({
         answers: checker.getQuestionAnswers(),
       },
     ]);
-  };
-
-  const goToConclusion = () => {
-    setActiveState("conclusion");
-    setFinishedState(["questions", "conslusion"], true);
-  };
-
-  const onQuestionNext = () => {
-    const question = checker.stack[questionIndex];
-
-    if (checker.needContactExit(question)) {
-      // Go directly to "Contact Conclusion" and skip other questions
-      goToConclusion();
-    } else {
-      // Load the next question or go to the "Conclusion"
-      if (checker.stack.length - 1 === questionIndex) {
-        // If the (stack length - 1) is equal to the questionIndex, we want to load a new question
-        const next = checker.next();
-
-        if (next) {
-          // Go to next question
-          goToQuestion("next");
-        } else {
-          // Go to the "Conclusion"
-          goToConclusion();
-        }
-      } else {
-        // In this case, the user is changing a previously answered question and we don't want to load a new question
-        goToQuestion("next");
-      }
-    }
-  };
-
-  const onQuestionPrev = () => {
-    // Load the previous question or go to "Location"
-    if (checker.stack.length > 1) {
-      // Store the new questionIndex in the session
-      goToQuestion("prev");
-    }
-    if (questionIndex === 0) {
-      setActiveState("locationResult");
-      setFinishedState("locationResult", false);
-      // This prevents to uncheck the Item that holds "questions" (when all questions are answered)
-      if (!isFinished("questions")) {
-        setFinishedState("questions", false);
-      }
-    }
-  };
-
-  const onGoToQuestion = (questionId) => {
-    // Checker rewinding also needs to work when you already have a conlusion
-    // Go to the specific question in the stack
-    setActiveState("questions");
-    setFinishedState(["conclusion", "questions"], false);
-    setFinishedState("locationResult", true);
-
-    goToQuestion(questionId);
   };
 
   if (checker.stack.length === 0) {

--- a/apps/client/src/components/Questions.js
+++ b/apps/client/src/components/Questions.js
@@ -16,6 +16,7 @@ const Questions = ({
 }) => {
   const sessionContext = useContext(SessionContext);
   const [skipAnsweredQuestions, setSkipAnsweredQuestions] = useState(false);
+  const [contactConclusion, setContactConclusion] = useState(false);
   const { questionIndex } = sessionContext[slug];
 
   const goToConclusion = useCallback(() => {
@@ -28,6 +29,7 @@ const Questions = ({
 
     if (checker.needContactExit(question)) {
       // Go directly to "Contact Conclusion" and skip other questions
+      setContactConclusion(true);
       goToConclusion();
     } else {
       // Load the next question or go to the "Conclusion"
@@ -132,6 +134,9 @@ const Questions = ({
       setFinishedState("questions", false);
     }
 
+    // Reset the ContactConclusion
+    setContactConclusion(false);
+
     const question = checker.stack[questionIndex];
     // Provide the user answers to the `sttr-checker`
     if (question.options && value !== undefined) {
@@ -219,14 +224,14 @@ const Questions = ({
           !q.options && booleanOptions.find((o) => o.value === q.answer);
         const userAnswer = q.options ? q.answer : booleanAnswers?.label;
 
-        // Skip unanswered questions
-        if (!userAnswer) return null;
-
-        // Check if currect question is causing a permit requirement
-        const questionNeedsPermit = !!permitsPerQuestion[i];
+        // Skip unanswered questions or in case of Contact Conclusion
+        if (!userAnswer || contactConclusion) return null;
 
         // Get new index
         const index = i + checker.stack.length;
+
+        // Check if currect question is causing a permit requirement
+        const questionNeedsPermit = !!permitsPerQuestion[index];
 
         return (
           <StepByStepItem
@@ -237,7 +242,7 @@ const Questions = ({
             key={`question-${q.id}-${index}`}
           >
             <QuestionAnswer
-              hideEditButton={!checker.isConclusive()}
+              hideEditButton={checker.isConclusive()}
               onClick={() => onGoToQuestion(index)}
               {...{ questionNeedsPermit, userAnswer }}
             />

--- a/apps/client/src/components/Questions.js
+++ b/apps/client/src/components/Questions.js
@@ -158,58 +158,91 @@ const Questions = ({
   }
 
   // Loop through all questions
-  return checker.stack.map((q, i) => {
-    // Define userAnswer
-    const booleanAnswers =
-      !q.options && booleanOptions.find((o) => o.value === q.answer);
-    const userAnswer = q.options ? q.answer : booleanAnswers?.label;
+  return (
+    <>
+      {checker.stack.map((q, i) => {
+        // Define userAnswer
+        const booleanAnswers =
+          !q.options && booleanOptions.find((o) => o.value === q.answer);
+        const userAnswer = q.options ? q.answer : booleanAnswers?.label;
 
-    // Define if question is the current one
-    const isCurrentQuestion =
-      q === checker.stack[questionIndex] && isActive("questions");
+        // Define if question is the current one
+        const isCurrentQuestion =
+          q === checker.stack[questionIndex] && isActive("questions");
 
-    // Hide unanswered questions (eg: on browser refresh)
-    if (!isCurrentQuestion && !userAnswer) return null;
+        // Hide unanswered questions (eg: on browser refresh)
+        if (!isCurrentQuestion && !userAnswer) return null;
 
-    // Check if currect question is causing a permit requirement
-    const questionNeedsPermit = !!permitsPerQuestion[i];
+        // Check if currect question is causing a permit requirement
+        const questionNeedsPermit = !!permitsPerQuestion[i];
 
-    return (
-      <StepByStepItem
-        active={isCurrentQuestion}
-        checked={userAnswer}
-        customSize
-        heading={q.text}
-        highlightActive={isCurrentQuestion}
-        key={`question-${q.id}-${i}`}
-        style={isCurrentQuestion ? activeStyle : {}}
-      >
-        {isCurrentQuestion ? (
-          // Show the current question
-          <Question
-            question={q}
-            onGoToPrev={onQuestionPrev}
-            onGoToNext={onQuestionNext}
-            saveAnswer={saveAnswer}
-            showNext
-            showPrev
-            {...{
-              checker,
-              questionIndex,
-              questionNeedsPermit,
-              userAnswer,
-            }}
-          />
-        ) : (
-          // Show the answer with an edit button
-          <QuestionAnswer
-            onClick={() => onGoToQuestion(i)}
-            {...{ questionNeedsPermit, userAnswer }}
-          />
-        )}
-      </StepByStepItem>
-    );
-  });
+        return (
+          <StepByStepItem
+            active={isCurrentQuestion}
+            checked={userAnswer}
+            customSize
+            heading={q.text}
+            highlightActive={isCurrentQuestion}
+            key={`question-${q.id}-${i}`}
+            style={isCurrentQuestion ? activeStyle : {}}
+          >
+            {isCurrentQuestion ? (
+              // Show the current question
+              <Question
+                question={q}
+                onGoToPrev={onQuestionPrev}
+                onGoToNext={onQuestionNext}
+                saveAnswer={saveAnswer}
+                showNext
+                showPrev
+                {...{
+                  checker,
+                  questionIndex,
+                  questionNeedsPermit,
+                  userAnswer,
+                }}
+              />
+            ) : (
+              // Show the answer with an edit button
+              <QuestionAnswer
+                onClick={() => onGoToQuestion(i)}
+                {...{ questionNeedsPermit, userAnswer }}
+              />
+            )}
+          </StepByStepItem>
+        );
+      })}
+      {checker._getUpcomingQuestions().map((q, i) => {
+        // @TODO: refactor this part
+        // Define userAnswer
+        const booleanAnswers =
+          !q.options && booleanOptions.find((o) => o.value === q.answer);
+        const userAnswer = q.options ? q.answer : booleanAnswers?.label;
+
+        // Check if currect question is causing a permit requirement
+        const questionNeedsPermit = !!permitsPerQuestion[i];
+
+        if (!userAnswer) return null;
+
+        return (
+          <StepByStepItem
+            active
+            checked
+            customSize
+            heading={q.text}
+            key={`question-${q.id}-${i}`}
+            // style={isCurrentQuestion ? activeStyle : {}}
+          >
+            <QuestionAnswer
+              hideEditButton
+              onClick={() => onGoToQuestion(i)}
+              {...{ questionNeedsPermit, userAnswer }}
+            />
+          </StepByStepItem>
+        );
+      })}
+    </>
+  );
 };
 
 export default Questions;

--- a/apps/client/src/pages/CheckerPage.js
+++ b/apps/client/src/pages/CheckerPage.js
@@ -19,8 +19,9 @@ import { geturl, routes } from "../routes";
 
 const CheckerPage = ({ checker, topic, resetChecker }) => {
   const sessionContext = useContext(SessionContext);
-  const { questionIndex } = sessionContext[topic.slug];
   const { slug, sttrFile } = topic;
+  // OLO Flow does not have questionIndex
+  const { questionIndex } = sttrFile ? sessionContext[topic.slug] : 0;
 
   //@TODO Quick fix, we shoudn't need this, refactor this so we always have activeComponents and finishComponents
   if (!sessionContext[slug]) {
@@ -115,6 +116,7 @@ const CheckerPage = ({ checker, topic, resetChecker }) => {
               heading="Adresgegevens"
               largeCircle
             >
+              {/* @TODO: Refactor this, because of duplicate code */}
               {isActive("locationInput") && (
                 <LocationInput
                   {...{
@@ -126,6 +128,7 @@ const CheckerPage = ({ checker, topic, resetChecker }) => {
                   }}
                 />
               )}
+              {/* @TODO: Refactor this, because of duplicate code */}
               {!isActive("locationInput") &&
                 (isActive("locationResult") ||
                   isFinished("locationResult")) && (
@@ -179,8 +182,9 @@ const CheckerPage = ({ checker, topic, resetChecker }) => {
         {/* OLO-flow only needs the Location component */}
         {!sttrFile && (
           <>
+            {/* @TODO: Refactor this, because of duplicate code */}
             {isActive("locationInput") && (
-              <LocationInput {...{ topic, setActiveState }} />
+              <LocationInput {...{ topic, setActiveState, setFinishedState }} />
             )}
             {isActive("locationResult") && (
               <LocationResult


### PR DESCRIPTION
## Feature request from UX: 
- Always show already answered questions
- "Go to next question" should skip already answered questions

### Showing and skipping answered questions works very nice, but has the following challenges:
- Now we need a solution to force the window to go to the conclusion(eg: "scroll") otherwise the user is on the top but the conclusion is in the bottom
- How does "go to previous question" work? If this is going one question up then it's inconsistent with "go to next question", because that skips (maybe the dynamic labels (Next question / Go to conclusion) will help
- We cannot always show the EditButton on answered questions, because otherwise you might skip a question in the past which you will never be able to see

### TODO:
- [x] Fix bug "edit" button for future answered questions
- [x] Fix bug ContactConclusion also shows irrelevant getUpcoming_Questions
- [x] OLO Flow error
- Refactor a lot (in another PR)
- Feedback from UX (in another PR)