### PR TITLE
Bug: OLO Flow had issues with routing to CheckerPage

### DIFF
--- a/apps/client/src/components/Location/LocationInput.js
+++ b/apps/client/src/components/Location/LocationInput.js
@@ -44,7 +44,7 @@ const LocationInput = ({
   const onSubmit = () => {
     if (address.postalCode) {
       // Detect if user is submitting the same address as currenly stored
-      if (sessionAddress.id && sessionAddress.id === address.id) {
+      if (hasSTTR && sessionAddress.id && sessionAddress.id === address.id) {
         if (isFinished("questions")) {
           setActiveState("conclusion");
         } else {
@@ -55,7 +55,9 @@ const LocationInput = ({
       }
 
       // Reset all previous finished states
-      setFinishedState(["locationResult", "questions", "conclusion"], false);
+      if (hasSTTR) {
+        setFinishedState(["locationResult", "questions", "conclusion"], false);
+      }
 
       trackEvent({
         category: "postcode-input",

--- a/apps/client/src/components/Nav.js
+++ b/apps/client/src/components/Nav.js
@@ -31,19 +31,23 @@ const Nav = ({
     const action = formEnds
       ? getslug(nextText.toLowerCase())
       : "form-volgende-knop";
+
     trackEvent({
       category,
       action,
       name,
     });
+
     if (onGoToNext) onGoToNext(e);
   };
+
   const handlePrevClick = (e) => {
     trackEvent({
       category,
       action: "form-vorige-knop",
       name,
     });
+
     if (onGoToPrev) onGoToPrev(e);
   };
 

--- a/apps/client/src/hoc/withChecker.js
+++ b/apps/client/src/hoc/withChecker.js
@@ -24,12 +24,6 @@ const withChecker = (Component) =>
       if (sttrFile) {
         initChecker();
       }
-      if (!sessionContext[slug]) {
-        sessionContext.setSessionData([
-          slug,
-          { activeComponents: ["locationInput"], finishedComponents: [] },
-        ]);
-      }
     });
 
     const initChecker = () => {

--- a/apps/client/src/hoc/withTopic.js
+++ b/apps/client/src/hoc/withTopic.js
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { useContext, useEffect } from "react";
 import { Redirect, useLocation, useParams } from "react-router-dom";
 
 import { topics } from "../config";
@@ -15,6 +15,16 @@ const withTopic = (Component) => (props) => {
 
   const topic = topics.find((t) => t.slug === slug);
   const params = new URLSearchParams(search);
+
+  useEffect(() => {
+    // Default settings to be able to open the CheckerPage
+    if (!sessionContext[slug]) {
+      sessionContext.setSessionData([
+        slug,
+        { activeComponents: ["locationInput"], finishedComponents: [] },
+      ]);
+    }
+  });
 
   if (params.get("resetChecker")) {
     checkerContext.checker = null;

--- a/apps/client/src/pages/CheckerPage.js
+++ b/apps/client/src/pages/CheckerPage.js
@@ -23,11 +23,11 @@ const CheckerPage = ({ checker, topic, resetChecker }) => {
   // OLO Flow does not have questionIndex
   const { questionIndex } = sttrFile ? sessionContext[topic.slug] : 0;
 
+  //@TODO: We shoudn't need this redirect. We need to refactor this
   if (!sessionContext[slug]) {
     return <Redirect to={geturl(routes.intro, topic)} />;
   }
 
-  //@TODO Quick fix, we shoudn't need this, refactor this so we always have activeComponents and finishComponents
   const { activeComponents, finishedComponents } = sessionContext[slug];
 
   // Only one component can be active at the same time.

--- a/apps/client/src/pages/CheckerPage.js
+++ b/apps/client/src/pages/CheckerPage.js
@@ -23,10 +23,11 @@ const CheckerPage = ({ checker, topic, resetChecker }) => {
   // OLO Flow does not have questionIndex
   const { questionIndex } = sttrFile ? sessionContext[topic.slug] : 0;
 
-  //@TODO Quick fix, we shoudn't need this, refactor this so we always have activeComponents and finishComponents
   if (!sessionContext[slug]) {
     return <Redirect to={geturl(routes.intro, topic)} />;
   }
+
+  //@TODO Quick fix, we shoudn't need this, refactor this so we always have activeComponents and finishComponents
   const { activeComponents, finishedComponents } = sessionContext[slug];
 
   // Only one component can be active at the same time.
@@ -191,15 +192,17 @@ const CheckerPage = ({ checker, topic, resetChecker }) => {
           <>
             {/* @TODO: Refactor this, because of duplicate code */}
             {isActive("locationInput") && (
-              <LocationInput {...{ topic, setActiveState, setFinishedState }} />
+              <LocationInput
+                {...{ isFinished, setActiveState, setFinishedState, topic }}
+              />
             )}
             {isActive("locationResult") && (
               <LocationResult
                 {...{
-                  topic,
                   isFinished,
                   setActiveState,
                   setFinishedState,
+                  topic,
                 }}
               />
             )}


### PR DESCRIPTION
In OLO Flow going from Intro to CheckerPage routed back to Intro because of this line in CheckerPage:
```
if (!sessionContext[slug]) {
    return <Redirect to={geturl(routes.intro, topic)} />;
  }
```

It turned out that the OLO flow was missing the default `sessionContext` settings, because they were set in `withChecker` instead of `withTopic`

Please validate both flows and merge.