### PR TITLE
Feature: Added temporary FormTitle style fix

### DIFF
--- a/apps/client/src/atoms/FormTitle.tsx
+++ b/apps/client/src/atoms/FormTitle.tsx
@@ -1,0 +1,17 @@
+import { FormTitle as FormTitleComp } from "@datapunt/asc-ui";
+import React, { ReactNode } from "react";
+import styled from "styled-components";
+
+// This file should be temporary, since this style overwrite is already fixed in asc-ui
+// However, the update contains too many breaking changes to upgrade now
+// @TODO: upgrade asc-ui and fix breaking changes
+const FormTitleStyle = styled(FormTitleComp)`
+  max-width: inherit;
+`;
+
+const FormTitle: React.FC<{ children: ReactNode }> = ({
+  children,
+  ...otherProps
+}) => <FormTitleStyle {...otherProps}>{children}</FormTitleStyle>;
+
+export default FormTitle;

--- a/apps/client/src/atoms/index.js
+++ b/apps/client/src/atoms/index.js
@@ -1,6 +1,7 @@
 import Alert from "./Alert";
 import ComponentWrapper from "./ComponentWrapper";
 import EditButton from "./EditButton";
+import FormTitle from "./FormTitle";
 import HideForPrint from "./HideForPrint";
 import List from "./List";
 import ListItem from "./ListItem";
@@ -12,6 +13,7 @@ export {
   Alert,
   ComponentWrapper,
   EditButton,
+  FormTitle,
   HideForPrint,
   List,
   ListItem,

--- a/apps/client/src/components/Layouts/BaseLayout.tsx
+++ b/apps/client/src/components/Layouts/BaseLayout.tsx
@@ -1,8 +1,8 @@
-import { Column, FormTitle, Row } from "@datapunt/asc-ui";
+import { Column, Row } from "@datapunt/asc-ui";
 import React, { useContext } from "react";
 import { Helmet } from "react-helmet";
 
-import { HideForPrint } from "../../atoms";
+import { FormTitle, HideForPrint } from "../../atoms";
 import { CheckerContext } from "../../context";
 import Footer from "../Footer";
 import Header from "../Header";


### PR DESCRIPTION
// This file should be temporary, since this style overwrite is already fixed in asc-ui
// However, the update contains too many breaking changes to upgrade now
// @TODO: upgrade asc-ui and fix breaking changes


Edit: I would still prefer the temporary fix
```
<FormTitle style={{ maxWidth: "inherit" }}>...
```