### PR TITLE
Bug: Usabilla exit polls

### DIFF
--- a/ci/nginx-deployed.conf
+++ b/ci/nginx-deployed.conf
@@ -32,7 +32,7 @@ server {
         root  /usr/share/nginx/html/;
         try_files $uri /index.html =404;
 
-        add_header Content-Security-Policy "default-src 'self'; script-src 'unsafe-inline' 'self' *.data.amsterdam.nl https://d6tizftlrpuof.cloudfront.net *.usabilla.com; img-src 'self' *.data.amsterdam.nl *.flolegal.app https://d6tizftlrpuof.cloudfront.net *.usabilla.com; style-src 'self' 'unsafe-inline' https://d6tizftlrpuof.cloudfront.net; connect-src 'self' *.data.amsterdam.nl *.usabilla.com";
+        add_header Content-Security-Policy "default-src 'self' https://d6tizftlrpuof.cloudfront.net; script-src 'unsafe-inline' 'self' *.data.amsterdam.nl https://d6tizftlrpuof.cloudfront.net *.usabilla.com; img-src 'self' *.data.amsterdam.nl *.flolegal.app https://d6tizftlrpuof.cloudfront.net *.usabilla.com; style-src 'self' 'unsafe-inline' https://d6tizftlrpuof.cloudfront.net; connect-src 'self' *.data.amsterdam.nl *.usabilla.com";
         add_header Feature-Policy "document-write 'self'; geolocation 'none'; camera 'none'; speaker 'none';";
         add_header Referrer-Policy no-referrer;
         add_header X-Content-Type-Options nosniff;


### PR DESCRIPTION
## Can we fix this for this release? > Please merge

Bug:
```
Refused to frame 'https://d6tizftlrpuof.cloudfront.net/' because it violates the following Content Security Policy directive: "default-src 'self'". Note that 'frame-src' was not explicitly set, so 'default-src' is used as a fallback.
```