### PR TITLE
Feature: disabled Matomo and replaced all event trackers 

### DIFF
--- a/apps/client/src/components/Conclusion.js
+++ b/apps/client/src/components/Conclusion.js
@@ -1,5 +1,4 @@
 import { Button, Heading, Paragraph } from "@datapunt/asc-ui";
-import { useMatomo } from "@datapunt/matomo-tracker-react";
 import React, { Fragment } from "react";
 import { isMobile } from "react-device-detect";
 
@@ -11,13 +10,12 @@ import {
   PrintOnly,
 } from "../atoms";
 import { Olo } from "../config";
+import withTracking from "../hoc/withTracking";
 import { sttrOutcomes } from "../sttr_client/models/checker";
 import ContactSentence from "./ContactSentence";
 import Markdown from "./Markdown";
 
-const Conclusion = ({ checker, topic: { slug } }) => {
-  const { trackEvent } = useMatomo();
-
+const Conclusion = ({ checker, matomoTrackEvent, topic: { slug } }) => {
   // find conclusions we want to display to the user
   const conclusions = checker?.permits
     .filter((permit) => !!permit.getOutputByDecisionId("dummy"))
@@ -60,7 +58,7 @@ const Conclusion = ({ checker, topic: { slug } }) => {
 
   const handlePermitButton = (e) => {
     e.preventDefault();
-    trackEvent({
+    matomoTrackEvent({
       category: "conclusie",
       action: "vergunning aanvragen",
       name: slug,
@@ -70,7 +68,7 @@ const Conclusion = ({ checker, topic: { slug } }) => {
   };
 
   const handlePrintButton = () => {
-    trackEvent({
+    matomoTrackEvent({
       category: "conclusie",
       action: "conclusie opslaan",
       name: slug,
@@ -139,4 +137,4 @@ const Conclusion = ({ checker, topic: { slug } }) => {
   );
 };
 
-export default Conclusion;
+export default withTracking(Conclusion);

--- a/apps/client/src/components/Layouts/DefaultLayout.tsx
+++ b/apps/client/src/components/Layouts/DefaultLayout.tsx
@@ -19,7 +19,7 @@ function DefaultLayout({
 
   useEffect(() => {
     matomoPageView();
-  }, [location, matomoPageView]);
+  }, [location.pathname, matomoPageView]);
 
   return <BaseLayout {...{ heading, children }} />;
 }

--- a/apps/client/src/components/Layouts/DefaultLayout.tsx
+++ b/apps/client/src/components/Layouts/DefaultLayout.tsx
@@ -19,7 +19,9 @@ function DefaultLayout({
 
   useEffect(() => {
     matomoPageView();
-  }, [location.pathname, matomoPageView]);
+    // @TODO: We need to fix this!
+    //eslint-disable-next-line
+  }, [location.pathname]);
 
   return <BaseLayout {...{ heading, children }} />;
 }

--- a/apps/client/src/components/Location/LocationInput.js
+++ b/apps/client/src/components/Location/LocationInput.js
@@ -1,11 +1,11 @@
 import { Heading, Paragraph } from "@datapunt/asc-ui";
-import { useMatomo } from "@datapunt/matomo-tracker-react";
 import React, { useContext, useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useHistory } from "react-router-dom";
 
 import { eventNames } from "../../config/matomo";
 import { CheckerContext, SessionContext } from "../../context";
+import withTracking from "../../hoc/withTracking";
 import { geturl, routes } from "../../routes";
 import Error from "../Error";
 import Form from "../Form";
@@ -14,14 +14,13 @@ import PhoneNumber from "../PhoneNumber";
 import LocationFinder from "./LocationFinder";
 
 const LocationInput = ({
-  isFinished,
+  matomoTrackEvent,
   resetChecker,
   setActiveState,
   setFinishedState,
   topic,
 }) => {
   const history = useHistory();
-  const { trackEvent } = useMatomo();
   const { clearErrors, errors, register, unregister, handleSubmit } = useForm();
   const sessionContext = useContext(SessionContext);
   const checkerContext = useContext(CheckerContext);
@@ -52,7 +51,7 @@ const LocationInput = ({
         return;
       }
 
-      trackEvent({
+      matomoTrackEvent({
         category: "postcode-input",
         action: `postcode - ${slug.replace("-", " ")}`,
         name: address.postalCode.substring(0, 4),
@@ -136,4 +135,4 @@ const LocationInput = ({
   );
 };
 
-export default LocationInput;
+export default withTracking(LocationInput);

--- a/apps/client/src/components/Nav.js
+++ b/apps/client/src/components/Nav.js
@@ -1,12 +1,12 @@
 import { ChevronLeft } from "@datapunt/asc-assets";
 import { Button } from "@datapunt/asc-ui";
-import { useMatomo } from "@datapunt/matomo-tracker-react";
 import PropTypes from "prop-types";
 import React, { useContext } from "react";
 import { useRouteMatch } from "react-router-dom";
 
 import { PrevButton } from "../atoms";
 import { CheckerContext } from "../context";
+import withTracking from "../hoc/withTracking";
 import { getslug, routeConfig } from "../routes";
 import { NEXT_BUTTON } from "../utils/test-ids";
 import { IconContainer, IconLeft, NavStyle } from "./NavStyle";
@@ -14,6 +14,7 @@ import { IconContainer, IconLeft, NavStyle } from "./NavStyle";
 const Nav = ({
   formEnds,
   nextText,
+  matomoTrackEvent,
   noMarginBottom,
   onGoToNext,
   onGoToPrev,
@@ -24,7 +25,6 @@ const Nav = ({
   const {
     topic: { slug: name },
   } = useContext(CheckerContext);
-  const { trackEvent } = useMatomo();
   const { path } = useRouteMatch();
   const route = routeConfig.find((route) => route.path === path);
   const category = route.matomoPage || route.name;
@@ -34,7 +34,7 @@ const Nav = ({
       ? getslug(nextText.toLowerCase())
       : "form-volgende-knop";
 
-    trackEvent({
+    matomoTrackEvent({
       category,
       action,
       name,
@@ -44,7 +44,7 @@ const Nav = ({
   };
 
   const handlePrevClick = (e) => {
-    trackEvent({
+    matomoTrackEvent({
       category,
       action: "form-vorige-knop",
       name,
@@ -102,4 +102,4 @@ Nav.propTypes = {
   style: PropTypes.object,
 };
 
-export default Nav;
+export default withTracking(Nav);

--- a/apps/client/src/hoc/withTracking.js
+++ b/apps/client/src/hoc/withTracking.js
@@ -13,7 +13,11 @@ const withTracking = (Component) => ({ ...props }) => {
       trackPageView({});
     }
   };
-  const matomoTrackEvent = ({ category, action, name }) => {
+  const matomoTrackEvent = ({ action, category, name }) => {
+    // Temporary disable Matomo trackevents
+    return;
+
+    // eslint-disable-next-line no-unreachable
     if (trackingEnabled()) {
       trackEvent({
         category,

--- a/apps/client/src/hoc/withTracking.js
+++ b/apps/client/src/hoc/withTracking.js
@@ -9,6 +9,7 @@ const withTracking = (Component) => ({ ...props }) => {
   const { trackEvent, trackPageView } = useMatomo();
 
   const matomoPageView = () => {
+    console.log("matomoPageView");
     if (trackingEnabled()) {
       trackPageView({});
     }

--- a/apps/client/src/hoc/withTracking.js
+++ b/apps/client/src/hoc/withTracking.js
@@ -1,6 +1,7 @@
 import { useMatomo } from "@datapunt/matomo-tracker-react";
 import React, { useContext } from "react";
 
+import { isProduction } from "../config";
 import { trackingEnabled } from "../config/matomo";
 import { CheckerContext } from "../context";
 
@@ -9,14 +10,15 @@ const withTracking = (Component) => ({ ...props }) => {
   const { trackEvent, trackPageView } = useMatomo();
 
   const matomoPageView = () => {
-    console.log("matomoPageView");
     if (trackingEnabled()) {
       trackPageView({});
     }
   };
   const matomoTrackEvent = ({ action, category, name }) => {
-    // Temporary disable Matomo trackevents
-    return;
+    // Temporary disable Matomo trackevents on production
+    if (isProduction) {
+      return;
+    }
 
     // eslint-disable-next-line no-unreachable
     if (trackingEnabled()) {


### PR DESCRIPTION
Second reviewer, please squash and merge.

- I disabled Matomo but kept the code intact to quickly re-enable
- I fixed a bug that causes almost every button to trigger a new pageview.
- `import { useMatomo } from "@datapunt/matomo-tracker-react";` is now only called inside `withTracking` 

Note: I purposely did not change the props order to prevent merge conflicts in other PR's.