### PR TITLE
Matomo refactor and improvements

### DIFF
--- a/apps/client/src/components/Conclusion.js
+++ b/apps/client/src/components/Conclusion.js
@@ -16,7 +16,7 @@ import { sttrOutcomes } from "../sttr_client/models/checker";
 import ContactSentence from "./ContactSentence";
 import Markdown from "./Markdown";
 
-const Conclusion = ({ checker, matomoTrackEvent, topic: { name } }) => {
+const Conclusion = ({ checker, matomoTrackEvent }) => {
   // find conclusions we want to display to the user
   const conclusions = checker?.permits
     .filter((permit) => !!permit.getOutputByDecisionId("dummy"))
@@ -61,7 +61,6 @@ const Conclusion = ({ checker, matomoTrackEvent, topic: { name } }) => {
     e.preventDefault();
     matomoTrackEvent({
       action: actions.CLICK_EXTERNAL_NAVIGATION,
-      category: name,
       name: eventNames.APPLY_FOR_PERMIT,
     });
     // Open OLO in new tab/window
@@ -71,7 +70,6 @@ const Conclusion = ({ checker, matomoTrackEvent, topic: { name } }) => {
   const handlePrintButton = () => {
     matomoTrackEvent({
       action: actions.DOWNLOAD,
-      category: name,
       name: eventNames.SAVE_CONCLUSION,
     });
     window.print();

--- a/apps/client/src/components/ContactSentence.tsx
+++ b/apps/client/src/components/ContactSentence.tsx
@@ -3,18 +3,18 @@ import React from "react";
 import PhoneNumber from "./PhoneNumber";
 
 type Props = {
-  eventLocation: string;
+  eventName: string;
   link?: boolean;
   openingSentence?: string;
 };
 
 export default ({
-  eventLocation,
+  eventName,
   link = true,
   openingSentence = "Bel in een van deze situaties de gemeente op", // This is the text before the phonenumber `14 020`
 }: Props) => (
   <>
-    {openingSentence} <PhoneNumber {...{ eventLocation, link }} />, maandag tot
-    en met vrijdag van 08.00 uur tot 18.00 uur.
+    {openingSentence} <PhoneNumber {...{ eventName, link }} />, maandag tot en
+    met vrijdag van 08.00 uur tot 18.00 uur.
   </>
 );

--- a/apps/client/src/components/Footer/Footer.js
+++ b/apps/client/src/components/Footer/Footer.js
@@ -28,7 +28,7 @@ const FirstColumn = () => (
         Bel het telefoonnummer{" "}
         <PhoneNumber
           darkBackground
-          eventLocation={sections.FOOTER}
+          eventName={sections.FOOTER}
           variant={null}
         />
       </strong>{" "}

--- a/apps/client/src/components/Footer/Footer.test.js
+++ b/apps/client/src/components/Footer/Footer.test.js
@@ -7,6 +7,11 @@ import Footer from ".";
 
 Object.defineProperty(window, "matchMedia", matchMedia);
 
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useParams: () => ({}),
+}));
+
 it("renders with text", () => {
   const { getByTestId } = render(<Footer />);
   expect(getByTestId(FOOTER)).toBeTruthy();

--- a/apps/client/src/components/Link.js
+++ b/apps/client/src/components/Link.js
@@ -1,9 +1,8 @@
 import { Link as StyledComponentLink } from "@datapunt/asc-ui";
 import PropTypes from "prop-types";
-import React, { useContext } from "react";
+import React from "react";
 
 import { actions } from "../config/matomo";
-import { CheckerContext } from "../context";
 import withTracking from "../hoc/withTracking";
 
 const Link = ({
@@ -14,14 +13,11 @@ const Link = ({
   matomoTrackEvent,
   ...rest
 }) => {
-  const checkerContext = useContext(CheckerContext);
-
   // The default action is CLICK_EXTERNAL_NAVIGATION, it can be overwritten.
   const onClick = () => {
-    if (eventName && checkerContext.topic.name) {
+    if (eventName) {
       matomoTrackEvent({
         action,
-        category: checkerContext.topic.name,
         name: eventName,
       });
     }
@@ -37,7 +33,6 @@ const Link = ({
 Link.propTypes = {
   action: PropTypes.string,
   children: PropTypes.node.isRequired,
-  category: PropTypes.string,
   href: PropTypes.string,
   eventName: PropTypes.string,
   internal: PropTypes.bool,

--- a/apps/client/src/components/Location/LocationFinder.js
+++ b/apps/client/src/components/Location/LocationFinder.js
@@ -171,7 +171,7 @@ const LocationFinder = (props) => {
             <Paragraph>
               Probeer het opnieuw. Of neem contact op met de gemeente op
               telefoonnummer{" "}
-              <PhoneNumber eventLocation={sections.ALERT_ADDRESS_NOT_FOUND} />.
+              <PhoneNumber eventName={sections.ALERT_ADDRESS_NOT_FOUND} />.
             </Paragraph>
           </Alert>
         </ComponentWrapper>

--- a/apps/client/src/components/Location/LocationFinder.js
+++ b/apps/client/src/components/Location/LocationFinder.js
@@ -5,7 +5,7 @@ import React, { useEffect, useState } from "react";
 
 import { Alert, ComponentWrapper } from "../../atoms";
 import { requiredFieldText } from "../../config";
-import { eventNames } from "../../config/matomo";
+import { sections } from "../../config/matomo";
 import { LOCATION_FOUND } from "../../utils/test-ids";
 import PhoneNumber from "../PhoneNumber";
 
@@ -171,7 +171,7 @@ const LocationFinder = (props) => {
             <Paragraph>
               Probeer het opnieuw. Of neem contact op met de gemeente op
               telefoonnummer{" "}
-              <PhoneNumber eventName={eventNames.ADDRESS_NOT_FOUND} />.
+              <PhoneNumber eventLocation={sections.ALERT_ADDRESS_NOT_FOUND} />.
             </Paragraph>
           </Alert>
         </ComponentWrapper>

--- a/apps/client/src/components/Location/LocationInput.js
+++ b/apps/client/src/components/Location/LocationInput.js
@@ -117,13 +117,13 @@ const LocationInput = ({
     <>
       {errorMessage && (
         <Error
-          heading="Helaas. Wij kunnen nu geen locatiegegevens opvragen waardoor u deze check op dit moment niet kunt doen."
+          heading="Helaas. Wij kunnen nu geen adresgegevens opvragen waardoor u deze check op dit moment niet kunt doen."
           stack={errorMessage?.stack}
         >
           <Paragraph>
             Probeer het later opnieuw. Of neem contact op met de gemeente op
             telefoonnummer{" "}
-            <PhoneNumber eventLocation={sections.LOCATION_INPUT} />.
+            <PhoneNumber eventLocation={sections.ALERT_LOCATION_INPUT} />.
           </Paragraph>
         </Error>
       )}

--- a/apps/client/src/components/Location/LocationInput.js
+++ b/apps/client/src/components/Location/LocationInput.js
@@ -25,7 +25,7 @@ const LocationInput = ({
   const sessionContext = useContext(SessionContext);
   const checkerContext = useContext(CheckerContext);
 
-  const { name, slug, sttrFile, text } = topic;
+  const { slug, sttrFile, text } = topic;
   const sessionAddress = sessionContext[slug]?.address || {};
   const hasSTTR = !!sttrFile;
 
@@ -46,7 +46,6 @@ const LocationInput = ({
     if (address.postalCode) {
       matomoTrackEvent({
         action: actions.CLICK_INTERNAL_NAVIGATION,
-        category: name,
         name: `${eventNames.FORWARD} ${sections.LOCATION_RESULT}`,
       });
 
@@ -59,7 +58,6 @@ const LocationInput = ({
 
       matomoTrackEvent({
         action: actions.SUBMIT_LOCATION,
-        category: name,
         name: address.postalCode.substring(0, 4),
       });
 
@@ -102,7 +100,6 @@ const LocationInput = ({
   const onGoToPrev = () => {
     matomoTrackEvent({
       action: actions.CLICK_INTERNAL_NAVIGATION,
-      category: name,
       name: `${eventNames.BACK} ${sections.INTRO}`,
     });
 

--- a/apps/client/src/components/Location/LocationInput.js
+++ b/apps/client/src/components/Location/LocationInput.js
@@ -123,7 +123,7 @@ const LocationInput = ({
           <Paragraph>
             Probeer het later opnieuw. Of neem contact op met de gemeente op
             telefoonnummer{" "}
-            <PhoneNumber eventLocation={sections.ALERT_LOCATION_INPUT} />.
+            <PhoneNumber eventName={sections.ALERT_LOCATION_INPUT} />.
           </Paragraph>
         </Error>
       )}

--- a/apps/client/src/components/Location/LocationResult.js
+++ b/apps/client/src/components/Location/LocationResult.js
@@ -43,7 +43,6 @@ const LocationResult = ({
 
       matomoTrackEvent({
         action: actions.CLICK_INTERNAL_NAVIGATION,
-        category: topic.name,
         name: `${eventNames.FORWARD} ${eventSection}`,
       });
 
@@ -55,7 +54,6 @@ const LocationResult = ({
     } else {
       matomoTrackEvent({
         action: actions.CLICK_EXTERNAL_NAVIGATION,
-        category: topic.name,
         name: eventNames.TO_OLO,
       });
       window.open(generateOloUrl(address), "_blank");
@@ -65,7 +63,6 @@ const LocationResult = ({
   const onGoToPrev = () => {
     matomoTrackEvent({
       action: actions.CLICK_INTERNAL_NAVIGATION,
-      category: topic.name,
       name: `${eventNames.BACK} ${sections.LOCATION_INPUT}`,
     });
     setActiveState(sections.LOCATION_INPUT);

--- a/apps/client/src/components/PhoneNumber.tsx
+++ b/apps/client/src/components/PhoneNumber.tsx
@@ -10,7 +10,7 @@ const Wrapper = styled.span`
 
 export type Props = {
   darkBackground?: boolean;
-  eventLocation: string;
+  eventName: string;
   href?: string;
   link?: boolean;
   text?: string;
@@ -19,7 +19,7 @@ export type Props = {
 
 export default ({
   darkBackground = false,
-  eventLocation,
+  eventName,
   href = "tel:14020",
   link = true,
   text = "14 020",
@@ -29,9 +29,9 @@ export default ({
     {link ? (
       <Link
         action={actions.CLICK_PHONE_LINK}
-        eventName={eventLocation}
         {...{
           darkBackground,
+          eventName,
           href,
           variant,
         }}

--- a/apps/client/src/components/Questions.js
+++ b/apps/client/src/components/Questions.js
@@ -27,10 +27,15 @@ const Questions = ({
     setFinishedState([sections.QUESTIONS, sections.CONCLUSION], true);
     matomoTrackEvent({
       action: checker.stack[questionIndex].text,
-      category: name,
       name: eventNames.GOTO_CONCLUSION,
     });
-  }, [checker.stack, matomoTrackEvent, name, questionIndex, setActiveState, setFinishedState]);
+  }, [
+    checker.stack,
+    matomoTrackEvent,
+    questionIndex,
+    setActiveState,
+    setFinishedState,
+  ]);
 
   const onQuestionNext = useCallback(() => {
     const question = checker.stack[questionIndex];
@@ -134,17 +139,10 @@ const Questions = ({
     if (isQuestionSectionActive) {
       matomoTrackEvent({
         action: checker.stack[questionIndex].text,
-        category: name,
         name: eventNames.ACTIVE_QUESTION,
       });
     }
-  }, [
-    checker.stack,
-    isQuestionSectionActive,
-    matomoTrackEvent,
-    name,
-    questionIndex,
-  ]);
+  }, [checker.stack, isQuestionSectionActive, matomoTrackEvent, questionIndex]);
 
   let disableFutureQuestions = false;
 

--- a/apps/client/src/components/RegisterLookupSummary.js
+++ b/apps/client/src/components/RegisterLookupSummary.js
@@ -18,7 +18,7 @@ const RegisterLookupSummary = ({
   displayZoningPlans,
   matomoTrackEvent,
   setActiveState,
-  topic: { name, sttrFile },
+  topic: { sttrFile },
 }) => {
   const { restrictions, zoningPlans } = address;
   const monument = getRestrictionByTypeName(restrictions, "Monument")?.name;
@@ -37,7 +37,6 @@ const RegisterLookupSummary = ({
           onClick={() => {
             matomoTrackEvent({
               action: actions.CLICK_INTERNAL_NAVIGATION,
-              category: name,
               name: eventNames.EDIT_ADDRESS,
             });
             setActiveState(sections.LOCATION_INPUT);

--- a/apps/client/src/config/matomo.js
+++ b/apps/client/src/config/matomo.js
@@ -26,6 +26,9 @@ export const actions = {
 };
 
 export const sections = {
+  ALERT_ADDRESS_NOT_FOUND:
+    "we kunnen geen adres vinden bij deze combinatie (melding)",
+  ALERT_LOCATION_INPUT: "we kunnen nu geen adresgegevens ophalen (melding)",
   CONCLUSION: "conclusie",
   FOOTER: "footer",
   HEADER: "header",
@@ -40,7 +43,6 @@ export const eventNames = {
   ACTIVE_QUESTION: "vraag is actief",
   ANSWERED_WITH: "beantwoord met",
   ADDRESS_ERROR: "adres error",
-  ADDRESS_NOT_FOUND: "adres niet gevonden",
   APPLY_FOR_PERMIT: "vergunning aanvragen",
   BACK: "terug naar",
   CONTACT_FORM: "contactformulier",

--- a/apps/client/src/hoc/withTracking.js
+++ b/apps/client/src/hoc/withTracking.js
@@ -1,11 +1,18 @@
 import { useMatomo } from "@datapunt/matomo-tracker-react";
 import React from "react";
+import { useParams } from "react-router-dom";
 
 import { isProduction } from "../config";
+import { topics } from "../config";
 import { trackingEnabled } from "../config/matomo";
 
 const withTracking = (Component) => ({ ...props }) => {
   const { trackEvent, trackPageView } = useMatomo();
+
+  // This is a temporary fix
+  // @TODO: make a withTacking hook instead of this HOC
+  const { slug } = useParams();
+  const topic = topics.find((t) => t.slug === slug);
 
   const matomoPageView = () => {
     if (trackingEnabled()) {
@@ -13,7 +20,7 @@ const withTracking = (Component) => ({ ...props }) => {
     }
   };
 
-  const matomoTrackEvent = ({ action, category, name }) => {
+  const matomoTrackEvent = ({ action, category = topic.name, name }) => {
     // Temporary disable Matomo trackevents on production
     if (isProduction) {
       return;

--- a/apps/client/src/intros/DakkapelIntro.js
+++ b/apps/client/src/intros/DakkapelIntro.js
@@ -39,7 +39,7 @@ export default () => (
       </ListItem>
     </List>
     <Paragraph>
-      <ContactSentence eventLocation={sections.INTRO} />
+      <ContactSentence eventName={sections.INTRO} />
     </Paragraph>
   </>
 );

--- a/apps/client/src/intros/DakraamIntro.js
+++ b/apps/client/src/intros/DakraamIntro.js
@@ -36,7 +36,7 @@ export default () => (
       </ListItem>
     </List>
     <Paragraph>
-      <ContactSentence eventLocation={sections.INTRO} />
+      <ContactSentence eventName={sections.INTRO} />
     </Paragraph>
   </>
 );

--- a/apps/client/src/intros/KozijnenIntro.js
+++ b/apps/client/src/intros/KozijnenIntro.js
@@ -35,7 +35,7 @@ export default () => (
       </ListItem>
     </List>
     <Paragraph>
-      <ContactSentence eventLocation={sections.INTRO} />
+      <ContactSentence eventName={sections.INTRO} />
     </Paragraph>
   </>
 );

--- a/apps/client/src/intros/ZonweringRolluikIntro.js
+++ b/apps/client/src/intros/ZonweringRolluikIntro.js
@@ -37,7 +37,7 @@ export default () => (
       </ListItem>
     </List>
     <Paragraph>
-      <ContactSentence eventLocation={sections.INTRO} />
+      <ContactSentence eventName={sections.INTRO} />
     </Paragraph>
   </>
 );

--- a/apps/client/src/pages/CheckerPage.js
+++ b/apps/client/src/pages/CheckerPage.js
@@ -21,7 +21,7 @@ import { geturl, routes } from "../routes";
 
 const CheckerPage = ({ checker, matomoTrackEvent, resetChecker, topic }) => {
   const sessionContext = useContext(SessionContext);
-  const { name, slug, sttrFile, text } = topic;
+  const { slug, sttrFile, text } = topic;
 
   // OLO Flow does not have questionIndex
   const { questionIndex } = sttrFile ? sessionContext[topic.slug] : 0;
@@ -41,7 +41,6 @@ const CheckerPage = ({ checker, matomoTrackEvent, resetChecker, topic }) => {
     if (!isActive(component)) {
       matomoTrackEvent({
         action: actions.ACTIVE_STEP,
-        category: name,
         name: component,
       });
     }
@@ -117,7 +116,6 @@ const CheckerPage = ({ checker, matomoTrackEvent, resetChecker, topic }) => {
 
     matomoTrackEvent({
       action,
-      category: name,
       name: eventName,
     });
 
@@ -245,7 +243,7 @@ const CheckerPage = ({ checker, matomoTrackEvent, resetChecker, topic }) => {
             style={{ marginTop: -1 }}
           >
             {isFinished(sections.QUESTIONS) && (
-              <Conclusion {...{ checker, topic, matomoTrackEvent }} />
+              <Conclusion {...{ checker, matomoTrackEvent }} />
             )}
           </StepByStepItem>
         </StepByStepNavigation>


### PR DESCRIPTION
Matomo refactor and improvements:
- `withTracking` now fetches the topic name itself, this makes it easier to convert to a custom hook
- Solved bugs in `PhoneNumber` props with unused `eventName`
- Renamed `eventLocation` to `eventName` where we directly passed those props through

Please make sure:
- [x] to add a label
- [x] to add one or more reviewers
- [x] you followed our checklist for [functional testing](https://github.com/Amsterdam/vergunningcheck/blob/master/TESTING.md)
- [x] you added the necessary documentation (either in the markdown files or inline)
- [x] you added the necessary automated tests


Please `npm run test` locally since tests fail on GH.

Please merge