### PR TITLE
Hide DebugDecisionTable on print

### DIFF
--- a/apps/client/src/pages/CheckerPage.js
+++ b/apps/client/src/pages/CheckerPage.js
@@ -2,6 +2,7 @@ import React, { useContext } from "react";
 import { Helmet } from "react-helmet";
 import { Redirect } from "react-router-dom";
 
+import { HideForPrint } from "../atoms";
 import Conclusion from "../components/Conclusion";
 import DebugDecisionTable from "../components/DebugDecisionTable";
 import Layout from "../components/Layouts/DefaultLayout";
@@ -225,7 +226,9 @@ const CheckerPage = ({ checker, topic, resetChecker }) => {
         </>
       )}
 
-      <DebugDecisionTable {...{ topic, checker }} />
+      <HideForPrint>
+        <DebugDecisionTable {...{ checker, topic }} />
+      </HideForPrint>
     </Layout>
   );
 };


### PR DESCRIPTION
When printing I don't want the DebugDecisionTable to show up there. It is very distracting.

Please make sure:
- [x] to add a label
- [x] to add one or more reviewers
- [x] you followed our checklist for [functional testing](https://github.com/Amsterdam/vergunningcheck/blob/master/TESTING.md)

Please merge @svenjens 