### PR TITLE
Bump lint-staged (to prevent `lint-staged: command not found`)

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -82,7 +82,7 @@
     "fast-xml-parser": "^3.17.4",
     "import-sort-style-module": "^6.0.0",
     "jest-styled-components": "^7.0.2",
-    "lint-staged": "^10.2.9",
+    "lint-staged": "^10.3.0",
     "lodash.get": "^4.4.2",
     "mkdirp": "^1.0.4",
     "node-fetch": "^2.6.0",


### PR DESCRIPTION
Somehow the dep update from lint-staged is causing an error on develop:
```
vergunningcheck-client: > lint-staged
vergunningcheck-client: sh: lint-staged: command not found
```
Running `npm i lint-staged@latest` fixed this issue.

Hotfix, please merge