### PR TITLE
Enable npm audit again

### DIFF
--- a/ci/Dockerfile.client
+++ b/ci/Dockerfile.client
@@ -3,9 +3,7 @@ LABEL maintainer="datapunt@amsterdam.nl"
 
 WORKDIR /app/
 COPY apps/client/package*.json ./
-
-# disabled because of rate limiting on npm/cloudflare
-# RUN npm audit --production
+RUN npm audit --production
 
 RUN npm ci --no-color -q
 COPY apps/client/ ./

--- a/ci/Dockerfile.graphql
+++ b/ci/Dockerfile.graphql
@@ -3,9 +3,7 @@ LABEL maintainer="datapunt@amsterdam.nl"
 
 WORKDIR /app/
 COPY apps/graphql/package*.json ./
-
-# disabled because of rate limiting on npm/cloudflare
-# RUN npm audit --production
+RUN npm audit --production
 
 FROM base
 COPY --from=base /app/ /app/


### PR DESCRIPTION
Testing if we can use npm audit again from our internal build-server.

Please make sure:
- [x] to add a label
- [ ] to add one or more reviewers
