### PR TITLE
Replaced div with span to prevent warning

### DIFF
--- a/apps/client/src/atoms/TextToEdit.tsx
+++ b/apps/client/src/atoms/TextToEdit.tsx
@@ -2,8 +2,7 @@ import { themeSpacing } from "@datapunt/asc-ui";
 import React from "react";
 import styled from "styled-components";
 
-const TextToEditStyle = styled.div`
-  display: inline-block;
+const TextToEditStyle = styled.span`
   margin-right: ${themeSpacing(5)};
 `;
 


### PR DESCRIPTION
This is a bugfix to prevent the warning `<div> cannot appear as a descendant of <p>`. Also, the EditButton gets pushed to a newline.

![image](https://user-images.githubusercontent.com/7781865/93224757-c3689e80-f771-11ea-8316-c11db7246cd6.png)


Please make sure:
- [x] to add a label
- [x] to add one or more reviewers
- [x] you followed our checklist for [functional testing](https://github.com/Amsterdam/vergunningcheck/blob/master/TESTING.md)
- [ ] you added the necessary documentation (either in the markdown files or inline)
- [ ] you added the necessary automated tests
