### PR TITLE
Redirect to Intro in case no session context has been found

### DIFF
--- a/apps/client/src/hoc/withChecker.js
+++ b/apps/client/src/hoc/withChecker.js
@@ -4,6 +4,7 @@ import { autofillMap, autofillResolvers } from "../config/autofill";
 import { CheckerContext, SessionContext } from "../context";
 import ErrorPage from "../pages/ErrorPage";
 import LoadingPage from "../pages/LoadingPage";
+import { geturl, routes } from "../routes";
 import getChecker from "../sttr_client";
 import withTopic from "./withTopic";
 
@@ -19,6 +20,12 @@ const withChecker = (Component) =>
     const { topic } = props;
     const { sttrFile, slug } = topic;
     const address = sessionContext[topic.slug]?.address;
+
+    // Redirect to Intro in case no session context has been found
+    if (!sessionContext[slug]) {
+      window.location.href = geturl(routes.intro, topic);
+      return null;
+    }
 
     useEffect(() => {
       if (sttrFile) {

--- a/apps/client/src/pages/CheckerPage.js
+++ b/apps/client/src/pages/CheckerPage.js
@@ -1,6 +1,5 @@
 import React, { useCallback, useContext, useEffect } from "react";
 import { Helmet } from "react-helmet";
-import { Redirect } from "react-router-dom";
 
 import { HideForPrint } from "../atoms";
 import Conclusion from "../components/Conclusion";
@@ -18,7 +17,6 @@ import { actions, eventNames, sections } from "../config/matomo";
 import { SessionContext } from "../context";
 import withChecker from "../hoc/withChecker";
 import withTracking from "../hoc/withTracking";
-import { geturl, routes } from "../routes";
 
 const CheckerPage = ({ checker, matomoTrackEvent, resetChecker, topic }) => {
   const sessionContext = useContext(SessionContext);
@@ -32,11 +30,6 @@ const CheckerPage = ({ checker, matomoTrackEvent, resetChecker, topic }) => {
   ];
 
   useEffect(() => {
-    //@TODO: We shoudn't need this redirect. We need to refactor this
-    if (!sessionContext[slug]) {
-      return <Redirect to={geturl(routes.intro, topic)} />;
-    }
-
     // In case no active sections are found, reset the checker
     // This is a fallback to prevent users being stuck without any active component
     const activeComponent = [


### PR DESCRIPTION
We get errors in Sentry that `activeComponents` is undefined, because the `sessionContext` has not been defined yet. This happens in case the CheckerPage is opened directly, before the `sessionContext` is loaded. This PR solves this problem by redirecting back to the intro page. This should be solved in a different way when we implement the custom topic and checker hooks.

Test this by opening a CheckerPage like `dakraam-plaatsen/vragen-en-conclusie` in an incognito window.

Please merge

Please make sure:
- [x] to add a label
- [x] to add one or more reviewers
- [x] you followed our checklist for [functional testing](https://github.com/Amsterdam/vergunningcheck/blob/master/TESTING.md)
- [x] you added the necessary documentation (either in the markdown files or inline)
- [ ] ~you added the necessary automated tests~
