### PR TITLE
feat: Enable matamo trackevents

### DIFF
--- a/apps/client/src/hoc/withTracking.js
+++ b/apps/client/src/hoc/withTracking.js
@@ -2,7 +2,6 @@ import { useMatomo } from "@datapunt/matomo-tracker-react";
 import React from "react";
 import { useParams } from "react-router-dom";
 
-import { isProduction } from "../config";
 import { topics } from "../config";
 import { trackingEnabled } from "../config/matomo";
 
@@ -21,12 +20,6 @@ const withTracking = (Component) => ({ ...props }) => {
   };
 
   const matomoTrackEvent = ({ action, category = topic.name, name }) => {
-    // Temporary disable Matomo trackevents on production
-    if (isProduction) {
-      return;
-    }
-
-    // eslint-disable-next-line no-unreachable
     if (trackingEnabled()) {
       trackEvent({
         action: action.toLowerCase(),


### PR DESCRIPTION
Description 
We want to enable tracking with matomo again. 

Please make sure:
- [x] to add a label
- [x] to add one or more reviewers
- [ ] you followed our checklist for [functional testing](https://github.com/Amsterdam/vergunningcheck/blob/master/TESTING.md)
- [ ] you added the necessary documentation (either in the markdown files or inline)
- [ ] you added the necessary automated tests
