### PR TITLE
Feat: updated housenumber select with default value

### DIFF
--- a/apps/client/src/components/Location/LocationFinder.js
+++ b/apps/client/src/components/Location/LocationFinder.js
@@ -136,7 +136,10 @@ const LocationFinder = (props) => {
           label="Toevoeging"
           value={exactMatch?.houseNumberFull || houseNumber}
           disabled={
-            notFoundAddress || graphqlError || (exactMatch && !addressMatches)
+            notFoundAddress ||
+            graphqlError ||
+            (exactMatch && !addressMatches) ||
+            !addressMatches
           }
           error={suffixError}
           onChange={(e) => {
@@ -144,7 +147,9 @@ const LocationFinder = (props) => {
             e.preventDefault();
           }}
         >
-          {addressMatches && <option>{firstSelectOption}</option>}
+          <option disabled={exactMatch?.houseNumberFull}>
+            {firstSelectOption}
+          </option>
           {addressMatches?.map((match) => (
             <option value={match.houseNumberFull} key={match.houseNumberFull}>
               {match.houseNumberFull}


### PR DESCRIPTION
Description 
This PR fixes a small bug where the default select option has no value

Please make sure:
- [x] to add a label
- [x] to add one or more reviewers
- [ ] you followed our checklist for [functional testing](https://github.com/Amsterdam/vergunningcheck/blob/master/TESTING.md)
- [ ] you added the necessary documentation (either in the markdown files or inline)
- [ ] you added the necessary automated tests
