### PR TITLE
Fix console warnings and leave the OLO flow the same 

### DIFF
--- a/apps/client/src/__mocks__/addressMockNoMonument.js
+++ b/apps/client/src/__mocks__/addressMockNoMonument.js
@@ -1,0 +1,12 @@
+export default {
+  houseNumberFull: "123",
+  postalCode: "1234 AB",
+  residence: "Amsterdam",
+  restrictions: [],
+  streetName: "streetname",
+  zoningPlans: [
+    {
+      name: "zoningplan",
+    },
+  ],
+};

--- a/apps/client/src/components/AddressLine.tsx
+++ b/apps/client/src/components/AddressLine.tsx
@@ -1,3 +1,4 @@
+import { Paragraph } from "@datapunt/asc-ui";
 import React from "react";
 
 type AddressLineProps = {
@@ -8,15 +9,17 @@ type AddressLineProps = {
 };
 
 export default ({
-   houseNumberFull,
-   postalCode,
-   residence,
-   streetName,
- }: AddressLineProps ) => (
+  houseNumberFull,
+  postalCode,
+  residence,
+  streetName,
+}: AddressLineProps) => (
   <>
-    {streetName} {houseNumberFull}
-    <div>
+    <Paragraph gutterBottom={0}>
+      {streetName} {houseNumberFull}
+    </Paragraph>
+    <Paragraph gutterBottom={16}>
       {postalCode} {residence}
-    </div>
+    </Paragraph>
   </>
 );

--- a/apps/client/src/components/RegisterLookupSummary.js
+++ b/apps/client/src/components/RegisterLookupSummary.js
@@ -2,7 +2,7 @@ import { Paragraph } from "@datapunt/asc-ui";
 import { setTag } from "@sentry/browser";
 import React, { useContext } from "react";
 
-import { ComponentWrapper, List, ListItem, TextToEdit } from "../atoms";
+import { ComponentWrapper, List, ListItem } from "../atoms";
 import { SessionContext } from "../context";
 import { getRestrictionByTypeName } from "../utils";
 import { uniqueFilter } from "../utils";
@@ -47,12 +47,10 @@ const RegisterLookupSummary = ({
         <AddressLine {...address} />
       ) : (
         <>
-          <TextToEdit>
-            <Paragraph strong gutterBottom={0}>
-              Ingevoerd adres:
-            </Paragraph>
-            <AddressLine {...address} />
-          </TextToEdit>
+          <Paragraph strong gutterBottom={0}>
+            Ingevoerd adres:
+          </Paragraph>
+          <AddressLine {...address} />
           <ChangeAddressModal {...{ hasSTTR, setActiveState, slug }} />
         </>
       )}

--- a/apps/client/src/components/RegisterLookupSummary.js
+++ b/apps/client/src/components/RegisterLookupSummary.js
@@ -43,31 +43,36 @@ const RegisterLookupSummary = ({
 
   return (
     <ComponentWrapper marginBottom={sttrFile ? "0" : null}>
-      <Paragraph gutterBottom={16}>
-        {compact ? (
-          <AddressLine {...address} />
-        ) : (
-          <>
-            <TextToEdit>
-              <Paragraph strong gutterBottom={0}>
-                Ingevoerd adres:
-              </Paragraph>
-              <AddressLine {...address} />
-            </TextToEdit>
-            <ChangeAddressModal {...{ hasSTTR, setActiveState, slug }} />
-          </>
-        )}
-      </Paragraph>
-      <Paragraph data-testid={LOCATION_RESTRICTION_MONUMENT} gutterBottom={0}>
-        {monument && `Het gebouw is een ${monument.toLowerCase()}.`}
-      </Paragraph>
-      <Paragraph
-        data-testid={LOCATION_RESTRICTION_CITYSCAPE}
-        gutterBottom={hasSTTR ? 0 : 16}
-      >
-        {cityScape &&
-          `Het gebouw ligt in een beschermd stads- of dorpsgezicht.`}
-      </Paragraph>
+      {compact ? (
+        <AddressLine {...address} />
+      ) : (
+        <>
+          <TextToEdit>
+            <Paragraph strong gutterBottom={0}>
+              Ingevoerd adres:
+            </Paragraph>
+            <AddressLine {...address} />
+          </TextToEdit>
+          <ChangeAddressModal {...{ hasSTTR, setActiveState, slug }} />
+        </>
+      )}
+      {(monument || !hasSTTR) && (
+        <Paragraph data-testid={LOCATION_RESTRICTION_MONUMENT} gutterBottom={0}>
+          {monument
+            ? `Het gebouw is een ${monument.toLowerCase()}.`
+            : "Het gebouw is geen monument."}
+        </Paragraph>
+      )}
+      {(cityScape || !hasSTTR) && (
+        <Paragraph
+          data-testid={LOCATION_RESTRICTION_CITYSCAPE}
+          gutterBottom={hasSTTR ? 0 : 16}
+        >
+          {cityScape
+            ? `Het gebouw ligt in een beschermd stads- of dorpsgezicht.`
+            : `Het gebouw ligt niet in een beschermd stads- of dorpsgezicht.`}
+        </Paragraph>
+      )}
 
       {!hasSTTR && !compact && (
         <>

--- a/apps/client/src/components/RegisterLookupSummary.test.js
+++ b/apps/client/src/components/RegisterLookupSummary.test.js
@@ -31,7 +31,7 @@ describe("RegisterLookupSummary", () => {
     );
   };
 
-  it("renders correctly in STTR Flow", () => {
+  it("renders correctly in STTR Flow if monument", () => {
     const topicMock = "dakraam-plaatsen";
     const topic = findTopicBySlug(topicMock);
     const { queryByText } = render(<WrapperWithContext topic={topic} />);
@@ -51,7 +51,32 @@ describe("RegisterLookupSummary", () => {
     });
   });
 
-  it("renders correctly in OLO Flow if monument", () => {
+  it("renders correctly in STTR Flow if NOT a monument", () => {
+    const topicMock = "dakraam-plaatsen";
+    const topic = findTopicBySlug(topicMock);
+    const { queryByText } = render(
+      <WrapperWithContext
+        addressFromLocation={addressMockNoMonument}
+        topic={topic}
+      />
+    );
+
+    expect(queryByText("Het gebouw is een monument.")).not.toBeInTheDocument();
+    expect(
+      queryByText("Het gebouw ligt in een beschermd stads- of dorpsgezicht.")
+    ).not.toBeInTheDocument();
+
+    // Expect NOT to find zoningplan info
+    expect(queryByText("zoningplan")).not.toBeInTheDocument();
+
+    expect(screen.getByText(/wijzig/i)).toBeInTheDocument();
+
+    act(() => {
+      fireEvent.click(screen.getByText(/wijzig/i));
+    });
+  });
+
+  it("renders correctly in OLO Flow if building is a monument", () => {
     const topicMock = "aanbouw-of-uitbouw-maken";
     const topic = findTopicBySlug(topicMock);
     const { queryByText } = render(
@@ -74,7 +99,7 @@ describe("RegisterLookupSummary", () => {
     });
   });
 
-  it("renders correctly in OLO Flow if no monument", () => {
+  it("renders correctly in OLO Flow if building is NOT a monument", () => {
     const topicMock = "aanbouw-of-uitbouw-maken";
     const topic = findTopicBySlug(topicMock);
     const { queryByText } = render(

--- a/apps/client/src/components/RegisterLookupSummary.test.js
+++ b/apps/client/src/components/RegisterLookupSummary.test.js
@@ -1,6 +1,7 @@
 import React from "react";
 
 import addressMock from "../__mocks__/addressMock";
+import addressMockNoMonument from "../__mocks__/addressMockNoMonument";
 import Context from "../__mocks__/context";
 import matchMedia from "../__mocks__/matchMedia";
 import { findTopicBySlug } from "../utils";
@@ -50,12 +51,44 @@ describe("RegisterLookupSummary", () => {
     });
   });
 
-  it("renders correctly in OLO Flow", () => {
+  it("renders correctly in OLO Flow if monument", () => {
     const topicMock = "aanbouw-of-uitbouw-maken";
     const topic = findTopicBySlug(topicMock);
     const { queryByText } = render(
       <WrapperWithContext addressFromLocation={addressMock} topic={topic} />
     );
+
+    expect(queryByText("Het gebouw is een monument.")).toBeInTheDocument();
+    expect(
+      queryByText("Het gebouw ligt in een beschermd stads- of dorpsgezicht.")
+    ).toBeInTheDocument();
+
+    // Expect to find zoningplan info
+    expect(queryByText("zoningplan")).toBeInTheDocument();
+
+    expect(screen.getByText(/wijzig/i)).toBeInTheDocument();
+    expect(screen.queryByTestId(EDIT_BUTTON)).toBeInTheDocument();
+
+    act(() => {
+      fireEvent.click(screen.getByText(/wijzig/i));
+    });
+  });
+
+  it("renders correctly in OLO Flow if no monument", () => {
+    const topicMock = "aanbouw-of-uitbouw-maken";
+    const topic = findTopicBySlug(topicMock);
+    const { queryByText } = render(
+      <WrapperWithContext
+        addressFromLocation={addressMockNoMonument}
+        topic={topic}
+      />
+    );
+    expect(queryByText("Het gebouw is geen monument.")).toBeInTheDocument();
+    expect(
+      queryByText(
+        "Het gebouw ligt niet in een beschermd stads- of dorpsgezicht."
+      )
+    ).toBeInTheDocument();
 
     // Expect to find zoningplan info
     expect(queryByText("zoningplan")).toBeInTheDocument();


### PR DESCRIPTION
Description 
This PR solves a console warning about nested elements. And readded some checks to make sure the OLO flow stays unchanged

Please make sure:
- [x] to add a label
- [x] to add one or more reviewers
- [x] you followed our checklist for [functional testing](https://github.com/Amsterdam/vergunningcheck/blob/master/TESTING.md)
- [x] you added the necessary documentation (either in the markdown files or inline)
- [x] you added the necessary automated tests
