### PR TITLE
Do not show back-button at the first question + Only store the address if the address has been found

### DIFF
--- a/apps/client/src/components/Location/LocationInput.js
+++ b/apps/client/src/components/Location/LocationInput.js
@@ -103,13 +103,15 @@ const LocationInput = ({
       name: `${eventNames.BACK} ${sections.INTRO}`,
     });
 
-    // @TODO: We need to give a warning or we need to store the checker data as well
-    sessionContext.setSessionData([
-      slug,
-      {
-        address,
-      },
-    ]);
+    // Only store the address if the address has been found, otherwise an empty address may overwrite an existing address
+    if (address) {
+      sessionContext.setSessionData([
+        slug,
+        {
+          address,
+        },
+      ]);
+    }
     history.push(geturl(routes.intro, topic));
   };
 

--- a/apps/client/src/components/Question.js
+++ b/apps/client/src/components/Question.js
@@ -151,10 +151,10 @@ const Question = ({
       <Nav
         formEnds={shouldGoToConlusion()}
         nextText={shouldGoToConlusion() ? "Naar conclusie" : "Volgende vraag"}
+        showPrev={questionIndex > 0} // Do not show back-button at the first question
         {...{
           onGoToPrev,
           showNext,
-          showPrev,
         }}
       />
     </Form>


### PR DESCRIPTION
Two fixes:
- Do not show back-button at the first question
- Only store the address if the address has been found

Please make sure:
- [x] to add a label
- [x] to add one or more reviewers
- [x] you followed our checklist for [functional testing](https://github.com/Amsterdam/vergunningcheck/blob/master/TESTING.md)
- [ ] you added the necessary documentation (either in the markdown files or inline)
- [ ] you added the necessary automated tests
