### PR TITLE
Disables the native browser auto-suggest

### DIFF
--- a/apps/client/src/components/Location/LocationFinder.js
+++ b/apps/client/src/components/Location/LocationFinder.js
@@ -170,14 +170,13 @@ const LocationFinder = ({
 
       <ComponentWrapper>
         <LocationTextField
+          autoComplete="off" // This disables the native browser auto-suggest
           error={houseNumberError}
           id="houseNumberFull"
           label="Huisnummer + toevoeging"
           name="houseNumber"
           onBlur={handleBlur}
           onChange={(e) => {
-            // @TODO: Fix the option to allow a space between the houseNumber and the suffix
-            // EG: houseNumber "762A" should trigger the AutoSuggest and now only "762 A" works (postalCode "1017LD")
             setHouseNumber(parseInt(e.target.value));
             setHouseNumberFull(e.target.value);
           }}


### PR DESCRIPTION
It's very annoying that the native browser auto-suggest hovers over our new auto-suggest. This way we disable that.

Please make sure:
- [x] to add a label
- [x] to add one or more reviewers
- [ ] you followed our checklist for [functional testing](https://github.com/Amsterdam/vergunningcheck/blob/master/TESTING.md)
- [x] you added the necessary documentation (either in the markdown files or inline)
- [ ] you added the necessary automated tests
