### PR TITLE
Updated @amsterdam ASC dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,20 @@ open up a pull request. See [README.md](README.md) for nomenclature.
 
 We use [Conventional Commits](https://www.conventionalcommits.org).
 
+## Styling
+
+We use [Amsterdam Styled Components](https://github.com/Amsterdam/amsterdam-styled-components/), see [Storybook](https://amsterdam.github.io/amsterdam-styled-components) which is an implementation of the [Amsterdam Design System](https://designsystem.amsterdam.nl).
+
+Example usage of the `Alert` component:
+
+```js
+import { Alert } from "@amsterdam/asc-ui";
+
+...
+
+<Alert content="content" heading="heading">
+```
+
 ## Updating permits
 
 If you want to use the latest permit-configuration (XML files from the sttr-builder) follow these steps.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ open up a pull request. See [README.md](README.md) for nomenclature.
 
 We use [Conventional Commits](https://www.conventionalcommits.org).
 
-## Styling
+## Styled Components
 
 We use [Amsterdam Styled Components](https://github.com/Amsterdam/amsterdam-styled-components/), see [Storybook](https://amsterdam.github.io/amsterdam-styled-components) which is an implementation of the [Amsterdam Design System](https://designsystem.amsterdam.nl).
 
@@ -19,6 +19,25 @@ import { Alert } from "@amsterdam/asc-ui";
 ...
 
 <Alert content="content" heading="heading">
+```
+
+## Styling usage of margin and padding
+
+Amsterdam uses a 4px grid, so all distances should be divided by 4. You can use the `themeSpacing` function from Amsterdam Styled Components for this.
+
+Example usage:
+
+```scss
+padding-top: ${themeSpacing(1)}; // This will have a padding of 1 * 4 = 4px
+padding-right: ${themeSpacing(2)}; // This will have a padding of 2 * 4 = 8px
+padding-bottom: ${themeSpacing(3)}; // This will have a padding of 3 * 4 = 12px
+padding-left: ${themeSpacing(4)}; // This will have a padding of 4 * 4 = 16px
+```
+
+To simplify things you can also use:
+
+```scss
+margin: ${themeSpacing(5, 0, 4)}; // margin: 20px 0 16px;
 ```
 
 ## Updating permits

--- a/apps/client/package-lock.json
+++ b/apps/client/package-lock.json
@@ -4,6 +4,24 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@amsterdam/asc-assets": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@amsterdam/asc-assets/-/asc-assets-0.25.1.tgz",
+      "integrity": "sha512-f4Y+Vw03BR7xJo0Ax2NasV8VbTgK3DQPkMFvcTI07kj1jgqnvB7Zg9vLLB74LRh/I1s1+l1jLvw5dUHmXgN3gg=="
+    },
+    "@amsterdam/asc-ui": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@amsterdam/asc-ui/-/asc-ui-0.25.1.tgz",
+      "integrity": "sha512-LTbWkeLd3j2/wcyQmB68IMFCTjcyDt/17+HqodiUen5BClplart5nTCFjGijduFdJxYH1fPQHfvrCYmVqpS/GQ==",
+      "requires": {
+        "@amsterdam/asc-assets": "^0.25.1",
+        "classnames": "^2.2.6",
+        "deepmerge": "^4.2.2",
+        "objectFitPolyfill": ">=2.3.0",
+        "polished": "^3.6.5",
+        "react-uid": "^2.3.0"
+      }
+    },
     "@apollo/client": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.1.4.tgz",
@@ -1262,24 +1280,6 @@
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-10.1.0.tgz",
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==",
       "dev": true
-    },
-    "@datapunt/asc-assets": {
-      "version": "0.24.3",
-      "resolved": "https://registry.npmjs.org/@datapunt/asc-assets/-/asc-assets-0.24.3.tgz",
-      "integrity": "sha512-SR8QFbRcVpKS3VtGX4oL/2j5ZkUFJ39+o+tN8BLSjfV3OBorS5uucw8X/GnLfBvOLaYrS4nY0SppvpUeA0M2Wg=="
-    },
-    "@datapunt/asc-ui": {
-      "version": "0.24.3",
-      "resolved": "https://registry.npmjs.org/@datapunt/asc-ui/-/asc-ui-0.24.3.tgz",
-      "integrity": "sha512-X63kT7KpXdv7bnwpYIEkV5aSUM+uSS0PBtzTOgpZqkHkFOX8K4dyxz5aosotDlyEUVzOSx6SjGT2aL9n7nkhOQ==",
-      "requires": {
-        "@datapunt/asc-assets": "^0.24.3",
-        "classnames": "^2.2.6",
-        "deepmerge": "^4.2.2",
-        "objectFitPolyfill": ">=2.3.0",
-        "polished": "^3.6.5",
-        "react-uid": "^2.3.0"
-      }
     },
     "@datapunt/matomo-tracker-js": {
       "version": "0.2.1",

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -6,9 +6,9 @@
     "node": "14"
   },
   "dependencies": {
+    "@amsterdam/asc-assets": "^0.25.1",
+    "@amsterdam/asc-ui": "^0.25.1",
     "@apollo/client": "^3.1.3",
-    "@datapunt/asc-assets": "^0.24.3",
-    "@datapunt/asc-ui": "^0.24.3",
     "@datapunt/matomo-tracker-react": "^0.2.1",
     "@sentry/browser": "^5.20.0",
     "dotenv-flow": "^3.1.0",

--- a/apps/client/src/atoms/Alert.tsx
+++ b/apps/client/src/atoms/Alert.tsx
@@ -1,4 +1,4 @@
-import { Alert } from "@datapunt/asc-ui";
+import { Alert } from "@amsterdam/asc-ui";
 import styled from "styled-components";
 
 export default styled(Alert)`

--- a/apps/client/src/atoms/ComponentWrapper.ts
+++ b/apps/client/src/atoms/ComponentWrapper.ts
@@ -1,4 +1,4 @@
-import { themeSpacing } from "@datapunt/asc-ui";
+import { themeSpacing } from "@amsterdam/asc-ui";
 import styled, { css } from "styled-components";
 
 type Props = {

--- a/apps/client/src/atoms/EditButton.tsx
+++ b/apps/client/src/atoms/EditButton.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@datapunt/asc-ui";
+import { Button } from "@amsterdam/asc-ui";
 import React from "react";
 import styled from "styled-components";
 

--- a/apps/client/src/atoms/FormTitle.tsx
+++ b/apps/client/src/atoms/FormTitle.tsx
@@ -1,4 +1,4 @@
-import { FormTitle as FormTitleComp } from "@datapunt/asc-ui";
+import { FormTitle as FormTitleComp } from "@amsterdam/asc-ui";
 import React, { ReactNode } from "react";
 import styled from "styled-components";
 

--- a/apps/client/src/atoms/Label.js
+++ b/apps/client/src/atoms/Label.js
@@ -1,4 +1,4 @@
-import { Label, themeSpacing } from "@datapunt/asc-ui";
+import { Label, themeSpacing } from "@amsterdam/asc-ui";
 import styled from "styled-components";
 
 export default styled(Label)`

--- a/apps/client/src/atoms/List.ts
+++ b/apps/client/src/atoms/List.ts
@@ -1,4 +1,4 @@
-import { List, themeSpacing } from "@datapunt/asc-ui";
+import { List, themeSpacing } from "@amsterdam/asc-ui";
 import styled, { css } from "styled-components";
 
 type Props = {

--- a/apps/client/src/atoms/ListItem.js
+++ b/apps/client/src/atoms/ListItem.js
@@ -1,4 +1,4 @@
-import { ListItem } from "@datapunt/asc-ui";
+import { ListItem } from "@amsterdam/asc-ui";
 import styled from "styled-components";
 
 export default styled(ListItem)`

--- a/apps/client/src/atoms/OrderedList.js
+++ b/apps/client/src/atoms/OrderedList.js
@@ -1,4 +1,4 @@
-import { OrderedList, themeSpacing } from "@datapunt/asc-ui";
+import { OrderedList, themeSpacing } from "@amsterdam/asc-ui";
 import styled from "styled-components";
 
 export default styled(OrderedList)`

--- a/apps/client/src/atoms/PrevButton.tsx
+++ b/apps/client/src/atoms/PrevButton.tsx
@@ -1,4 +1,4 @@
-import { Button, themeSpacing } from "@datapunt/asc-ui";
+import { Button, themeSpacing } from "@amsterdam/asc-ui";
 import React, { ReactNode } from "react";
 import styled from "styled-components";
 

--- a/apps/client/src/atoms/PrintButton.ts
+++ b/apps/client/src/atoms/PrintButton.ts
@@ -1,4 +1,4 @@
-import { Button, themeSpacing } from "@datapunt/asc-ui";
+import { Button, themeSpacing } from "@amsterdam/asc-ui";
 import styled, { css } from "styled-components";
 
 type Props = {

--- a/apps/client/src/atoms/PrintOnly.tsx
+++ b/apps/client/src/atoms/PrintOnly.tsx
@@ -1,4 +1,4 @@
-import { themeColor } from "@datapunt/asc-ui";
+import { themeColor } from "@amsterdam/asc-ui";
 import styled, { css } from "styled-components";
 
 import { printOnly } from "../utils/themeUtils";

--- a/apps/client/src/atoms/TextToEdit.tsx
+++ b/apps/client/src/atoms/TextToEdit.tsx
@@ -1,4 +1,4 @@
-import { themeSpacing } from "@datapunt/asc-ui";
+import { themeSpacing } from "@amsterdam/asc-ui";
 import React from "react";
 import styled from "styled-components";
 

--- a/apps/client/src/components/Answers.tsx
+++ b/apps/client/src/components/Answers.tsx
@@ -1,4 +1,4 @@
-import { ErrorMessage, Radio, RadioGroup } from "@datapunt/asc-ui";
+import { ErrorMessage, Radio, RadioGroup } from "@amsterdam/asc-ui";
 import React from "react";
 
 import { ComponentWrapper, Label } from "../atoms";

--- a/apps/client/src/components/Conclusion.tsx
+++ b/apps/client/src/components/Conclusion.tsx
@@ -1,4 +1,4 @@
-import { themeSpacing } from "@datapunt/asc-ui";
+import { themeSpacing } from "@amsterdam/asc-ui";
 import React from "react";
 import styled from "styled-components";
 

--- a/apps/client/src/components/Conclusion/ConclusionOutcome.tsx
+++ b/apps/client/src/components/Conclusion/ConclusionOutcome.tsx
@@ -1,4 +1,4 @@
-import { Heading, Paragraph, themeSpacing } from "@datapunt/asc-ui";
+import { Heading, Paragraph, themeSpacing } from "@amsterdam/asc-ui";
 import React, { ReactNode, useEffect } from "react";
 import { isIE, isMobile } from "react-device-detect";
 import styled from "styled-components";

--- a/apps/client/src/components/Conclusion/NeedPermitContent.tsx
+++ b/apps/client/src/components/Conclusion/NeedPermitContent.tsx
@@ -1,4 +1,4 @@
-import { Button, Link, Paragraph } from "@datapunt/asc-ui";
+import { Button, Link, Paragraph } from "@amsterdam/asc-ui";
 import React from "react";
 
 import { HideForPrint, PrintOnly } from "../../atoms";

--- a/apps/client/src/components/Conclusion/NeedPermitFooter.tsx
+++ b/apps/client/src/components/Conclusion/NeedPermitFooter.tsx
@@ -1,4 +1,4 @@
-import { Heading, Paragraph } from "@datapunt/asc-ui";
+import { Heading, Paragraph } from "@amsterdam/asc-ui";
 import React from "react";
 
 import { urls } from "../../config";

--- a/apps/client/src/components/Conclusion/NewCheckerModal.tsx
+++ b/apps/client/src/components/Conclusion/NewCheckerModal.tsx
@@ -1,4 +1,4 @@
-import { ErrorMessage, Paragraph, Radio, RadioGroup } from "@datapunt/asc-ui";
+import { ErrorMessage, Paragraph, Radio, RadioGroup } from "@amsterdam/asc-ui";
 import React, { useContext, useState } from "react";
 import { useParams } from "react-router-dom";
 

--- a/apps/client/src/components/Conclusion/NoPermitDescription.tsx
+++ b/apps/client/src/components/Conclusion/NoPermitDescription.tsx
@@ -1,4 +1,4 @@
-import { Heading, ListItem, Paragraph } from "@datapunt/asc-ui";
+import { Heading, ListItem, Paragraph } from "@amsterdam/asc-ui";
 import React from "react";
 
 import { List } from "../../atoms/index";

--- a/apps/client/src/components/ConclusionAlert.tsx
+++ b/apps/client/src/components/ConclusionAlert.tsx
@@ -1,4 +1,4 @@
-import { Paragraph } from "@datapunt/asc-ui";
+import { Paragraph } from "@amsterdam/asc-ui";
 import React from "react";
 
 import { HideForPrint } from "../atoms";

--- a/apps/client/src/components/ConclusionAlertStyles.ts
+++ b/apps/client/src/components/ConclusionAlertStyles.ts
@@ -1,4 +1,4 @@
-import { themeSpacing } from "@datapunt/asc-ui";
+import { themeSpacing } from "@amsterdam/asc-ui";
 import styled from "styled-components";
 
 import { Alert } from "../atoms";

--- a/apps/client/src/components/Disclaimer.tsx
+++ b/apps/client/src/components/Disclaimer.tsx
@@ -1,4 +1,4 @@
-import { Alert, Paragraph } from "@datapunt/asc-ui";
+import { Alert, Paragraph } from "@amsterdam/asc-ui";
 import React from "react";
 
 import { DISCLAIMER_TEXT } from "../utils/test-ids";

--- a/apps/client/src/components/Footer/Footer.js
+++ b/apps/client/src/components/Footer/Footer.js
@@ -7,7 +7,7 @@ import {
   FooterTop,
   Paragraph,
   Row,
-} from "@datapunt/asc-ui";
+} from "@amsterdam/asc-ui";
 import React, { memo } from "react";
 
 import { List, ListItem } from "../../atoms";

--- a/apps/client/src/components/Footer/FooterStyles.js
+++ b/apps/client/src/components/Footer/FooterStyles.js
@@ -1,4 +1,4 @@
-import { breakpoint, themeSpacing } from "@datapunt/asc-ui";
+import { breakpoint, themeSpacing } from "@amsterdam/asc-ui";
 import styled from "styled-components";
 
 export const ContentContainer = styled.div`
@@ -6,9 +6,10 @@ export const ContentContainer = styled.div`
   width: 100%;
   margin: 0 auto;
 
-  @media screen and ${breakpoint("min-width", "tabletS")} and
-  ${breakpoint("max-width", "laptop")}
-  {
+  @media screen and ${breakpoint("min-width", "tabletS")} and ${breakpoint(
+      "max-width",
+      "laptop"
+    )} {
     padding-left: ${themeSpacing(4)};
     padding-right: ${themeSpacing(4)};
   }

--- a/apps/client/src/components/HeaderStyles.ts
+++ b/apps/client/src/components/HeaderStyles.ts
@@ -1,4 +1,4 @@
-import { Header, breakpoint, themeSpacing } from "@datapunt/asc-ui";
+import { Header, breakpoint, themeSpacing } from "@amsterdam/asc-ui";
 import styled, { css } from "styled-components";
 
 import LogoDesktop from "../static/media/logo-desktop.svg";

--- a/apps/client/src/components/Layouts/BaseLayout.tsx
+++ b/apps/client/src/components/Layouts/BaseLayout.tsx
@@ -1,4 +1,4 @@
-import { Column, Row } from "@datapunt/asc-ui";
+import { Column, Row } from "@amsterdam/asc-ui";
 import React, { useContext } from "react";
 import { Helmet } from "react-helmet";
 

--- a/apps/client/src/components/Layouts/BaseLayoutStyles.js
+++ b/apps/client/src/components/Layouts/BaseLayoutStyles.js
@@ -1,4 +1,4 @@
-import { breakpoint, themeColor, themeSpacing } from "@datapunt/asc-ui";
+import { breakpoint, themeColor, themeSpacing } from "@amsterdam/asc-ui";
 import styled from "styled-components";
 
 export const Container = styled.div`

--- a/apps/client/src/components/Link.js
+++ b/apps/client/src/components/Link.js
@@ -1,4 +1,4 @@
-import { Link as StyledComponentLink } from "@datapunt/asc-ui";
+import { Link as StyledComponentLink } from "@amsterdam/asc-ui";
 import PropTypes from "prop-types";
 import React from "react";
 

--- a/apps/client/src/components/Location/LocationFinder.js
+++ b/apps/client/src/components/Location/LocationFinder.js
@@ -1,5 +1,5 @@
+import { ErrorMessage, Paragraph, Select, TextField } from "@amsterdam/asc-ui";
 import { useQuery } from "@apollo/client";
-import { ErrorMessage, Paragraph, Select, TextField } from "@datapunt/asc-ui";
 import { loader } from "graphql.macro";
 import React, { useEffect, useState } from "react";
 

--- a/apps/client/src/components/Location/LocationInput.js
+++ b/apps/client/src/components/Location/LocationInput.js
@@ -1,4 +1,4 @@
-import { Heading, Paragraph } from "@datapunt/asc-ui";
+import { Heading, Paragraph } from "@amsterdam/asc-ui";
 import React, { useContext, useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useHistory } from "react-router-dom";

--- a/apps/client/src/components/Location/LocationResult.js
+++ b/apps/client/src/components/Location/LocationResult.js
@@ -1,4 +1,4 @@
-import { Heading, Paragraph } from "@datapunt/asc-ui";
+import { Heading, Paragraph } from "@amsterdam/asc-ui";
 import React, { useContext } from "react";
 
 import { generateOloUrl } from "../../config";

--- a/apps/client/src/components/Markdown/renderers/BlockRendererStyles.js
+++ b/apps/client/src/components/Markdown/renderers/BlockRendererStyles.js
@@ -1,4 +1,4 @@
-import { Paragraph, themeSpacing } from "@datapunt/asc-ui";
+import { Paragraph, themeSpacing } from "@amsterdam/asc-ui";
 import styled from "styled-components";
 
 export const StyledParagraph = styled(Paragraph)`

--- a/apps/client/src/components/Modal.tsx
+++ b/apps/client/src/components/Modal.tsx
@@ -1,5 +1,5 @@
-import { Close } from "@datapunt/asc-assets";
-import { CompactThemeProvider, Divider, Icon, TopBar } from "@datapunt/asc-ui";
+import { Close } from "@amsterdam/asc-assets";
+import { CompactThemeProvider, Divider, Icon, TopBar } from "@amsterdam/asc-ui";
 import React, { useState } from "react";
 
 import {

--- a/apps/client/src/components/ModalStyles.tsx
+++ b/apps/client/src/components/ModalStyles.tsx
@@ -1,4 +1,4 @@
-import { Button, Heading, Modal, themeSpacing } from "@datapunt/asc-ui";
+import { Button, Heading, Modal, themeSpacing } from "@amsterdam/asc-ui";
 import styled from "styled-components";
 
 export const ModalUI = styled(Modal)`

--- a/apps/client/src/components/Nav.tsx
+++ b/apps/client/src/components/Nav.tsx
@@ -1,5 +1,5 @@
-import { ChevronLeft } from "@datapunt/asc-assets";
-import { Button } from "@datapunt/asc-ui";
+import { ChevronLeft } from "@amsterdam/asc-assets";
+import { Button } from "@amsterdam/asc-ui";
 import React from "react";
 
 import { PrevButton } from "../atoms";

--- a/apps/client/src/components/NavStyle.ts
+++ b/apps/client/src/components/NavStyle.ts
@@ -1,4 +1,4 @@
-import { Icon, themeColor, themeSpacing } from "@datapunt/asc-ui";
+import { Icon, themeColor, themeSpacing } from "@amsterdam/asc-ui";
 import styled, { css } from "styled-components";
 
 import { NavProps } from "./Nav";

--- a/apps/client/src/components/PrintDetails.js
+++ b/apps/client/src/components/PrintDetails.js
@@ -1,4 +1,4 @@
-import { Heading, Paragraph } from "@datapunt/asc-ui";
+import { Heading, Paragraph } from "@amsterdam/asc-ui";
 import React from "react";
 
 import { PrintOnly } from "../atoms";

--- a/apps/client/src/components/QuestionAnswer.tsx
+++ b/apps/client/src/components/QuestionAnswer.tsx
@@ -1,4 +1,4 @@
-import { Paragraph } from "@datapunt/asc-ui";
+import { Paragraph } from "@amsterdam/asc-ui";
 import React from "react";
 
 import { EditButton, TextToEdit } from "../atoms";

--- a/apps/client/src/components/RegisterLookupSummary.js
+++ b/apps/client/src/components/RegisterLookupSummary.js
@@ -1,4 +1,4 @@
-import { Paragraph } from "@datapunt/asc-ui";
+import { Paragraph } from "@amsterdam/asc-ui";
 import { setTag } from "@sentry/browser";
 import React from "react";
 

--- a/apps/client/src/components/StepByStepNavigation/StepByStepItem.tsx
+++ b/apps/client/src/components/StepByStepNavigation/StepByStepItem.tsx
@@ -1,4 +1,4 @@
-import { Checkmark } from "@datapunt/asc-assets";
+import { Checkmark } from "@amsterdam/asc-assets";
 import React from "react";
 
 import { STEPBYSTEPITEM } from "../../utils/test-ids";

--- a/apps/client/src/components/StepByStepNavigation/StepByStepItemStyle.ts
+++ b/apps/client/src/components/StepByStepNavigation/StepByStepItemStyle.ts
@@ -1,4 +1,4 @@
-import { Icon, breakpoint, themeColor, themeSpacing } from "@datapunt/asc-ui";
+import { Icon, breakpoint, themeColor, themeSpacing } from "@amsterdam/asc-ui";
 import styled, { css } from "styled-components";
 
 export type Props = {

--- a/apps/client/src/components/StepByStepNavigation/StepByStepNavigation.test.tsx
+++ b/apps/client/src/components/StepByStepNavigation/StepByStepNavigation.test.tsx
@@ -1,6 +1,6 @@
 import "jest-styled-components";
 
-import { ascDefaultTheme, themeColor, themeSpacing } from "@datapunt/asc-ui";
+import { ascDefaultTheme, themeColor, themeSpacing } from "@amsterdam/asc-ui";
 import React from "react";
 
 import { STEPBYSTEPITEM, STEPBYSTEPNAVIGATION } from "../../utils/test-ids";

--- a/apps/client/src/components/StepByStepNavigation/StepByStepNavigation.tsx
+++ b/apps/client/src/components/StepByStepNavigation/StepByStepNavigation.tsx
@@ -1,4 +1,4 @@
-import { themeColor } from "@datapunt/asc-ui";
+import { themeColor } from "@amsterdam/asc-ui";
 import React from "react";
 
 import passPropsToChildren from "../../utils/passPropsToChildren";

--- a/apps/client/src/components/StepByStepNavigation/StepByStepNavigationStyle.ts
+++ b/apps/client/src/components/StepByStepNavigation/StepByStepNavigationStyle.ts
@@ -1,4 +1,4 @@
-import { themeColor } from "@datapunt/asc-ui";
+import { themeColor } from "@amsterdam/asc-ui";
 import styled, { css } from "styled-components";
 
 import StepByStepItemStyle, { CircleWrapperStyle } from "./StepByStepItemStyle";
@@ -14,7 +14,6 @@ export type Props = {
 export default styled.div<Props>`
   /* Remove the line (going downwards) only from the last Item */
   ${StepByStepItemStyle} {
-
     ${({ lineBetweenItems }) =>
       lineBetweenItems &&
       css`

--- a/apps/client/src/components/StepByStepNavigation/StepByStepTitle.tsx
+++ b/apps/client/src/components/StepByStepNavigation/StepByStepTitle.tsx
@@ -1,4 +1,4 @@
-import { Heading, Paragraph } from "@datapunt/asc-ui";
+import { Heading, Paragraph } from "@amsterdam/asc-ui";
 import React from "react";
 
 import { Props } from "./StepByStepItemStyle";

--- a/apps/client/src/components/VisualStyles.js
+++ b/apps/client/src/components/VisualStyles.js
@@ -4,7 +4,7 @@ import {
   perceivedLoading,
   themeColor,
   themeSpacing,
-} from "@datapunt/asc-ui";
+} from "@amsterdam/asc-ui";
 import styled, { css } from "styled-components";
 
 export const Caption = styled(Paragraph)`

--- a/apps/client/src/index.js
+++ b/apps/client/src/index.js
@@ -1,9 +1,9 @@
 import "react-app-polyfill/ie11";
 import "react-app-polyfill/stable";
-import "@datapunt/asc-assets/static/fonts/fonts.css";
+import "@amsterdam/asc-assets/static/fonts/fonts.css";
 
+import { GlobalStyle, ThemeProvider, themeColor } from "@amsterdam/asc-ui";
 import { ApolloProvider } from "@apollo/client";
-import { GlobalStyle, ThemeProvider, themeColor } from "@datapunt/asc-ui";
 import { MatomoProvider, createInstance } from "@datapunt/matomo-tracker-react";
 import { init } from "@sentry/browser";
 import dotenv from "dotenv-flow";

--- a/apps/client/src/intros/shared/DefaultOloIntro.js
+++ b/apps/client/src/intros/shared/DefaultOloIntro.js
@@ -1,4 +1,4 @@
-import { Heading, Paragraph } from "@datapunt/asc-ui";
+import { Heading, Paragraph } from "@amsterdam/asc-ui";
 import React from "react";
 
 import { List, ListItem } from "../../atoms";

--- a/apps/client/src/intros/shared/Intro.tsx
+++ b/apps/client/src/intros/shared/Intro.tsx
@@ -1,4 +1,4 @@
-import { Heading, Paragraph } from "@datapunt/asc-ui";
+import { Heading, Paragraph } from "@amsterdam/asc-ui";
 import React from "react";
 
 import { List, ListItem } from "../../atoms";

--- a/apps/client/src/pages/NotFoundPage.js
+++ b/apps/client/src/pages/NotFoundPage.js
@@ -1,4 +1,4 @@
-import { Heading, Paragraph } from "@datapunt/asc-ui";
+import { Heading, Paragraph } from "@amsterdam/asc-ui";
 import React from "react";
 import { Helmet } from "react-helmet";
 

--- a/apps/client/src/pages/RedirectPage.js
+++ b/apps/client/src/pages/RedirectPage.js
@@ -1,4 +1,4 @@
-import { Paragraph } from "@datapunt/asc-ui";
+import { Paragraph } from "@amsterdam/asc-ui";
 import React, { useEffect } from "react";
 import { Helmet } from "react-helmet";
 

--- a/apps/client/src/pages/StepperPage.jsx
+++ b/apps/client/src/pages/StepperPage.jsx
@@ -1,7 +1,7 @@
 // THIS PAGE IS FOR DEMO PURPOSES ONLY
 // DONT REVIEW THIS PAGE EXTENSIVELY
 
-import { Heading, Paragraph, themeColor } from "@datapunt/asc-ui";
+import { Heading, Paragraph, themeColor } from "@amsterdam/asc-ui";
 import React, { useState } from "react";
 import { Helmet } from "react-helmet";
 

--- a/apps/client/src/utils/test-utils.js
+++ b/apps/client/src/utils/test-utils.js
@@ -1,6 +1,6 @@
+import { ThemeProvider } from "@amsterdam/asc-ui";
 import { ApolloClient, ApolloProvider, InMemoryCache } from "@apollo/client";
 import { MockLink } from "@apollo/client/testing";
-import { ThemeProvider } from "@datapunt/asc-ui";
 import { MatomoProvider, createInstance } from "@datapunt/matomo-tracker-react";
 import { render } from "@testing-library/react";
 import dotenv from "dotenv-flow";


### PR DESCRIPTION
Our ownership at npmjs changed, so `@datapunt` dependencies are now replaced by `@amsterdam`.

Also bumped `asc-ui` and `asc-assets` from 0.24.3 to 0.25.1

Please make sure:
- [x] to add a label
- [x] to add one or more reviewers
- [x] you followed our checklist for [functional testing](https://github.com/Amsterdam/vergunningcheck/blob/master/TESTING.md)
- [ ] you added the necessary documentation (either in the markdown files or inline)
- [ ] you added the necessary automated tests
