### PR TITLE
Fixed bugs by making app backwards compatible

### DIFF
--- a/apps/client/src/pages/CheckerPage.js
+++ b/apps/client/src/pages/CheckerPage.js
@@ -24,11 +24,11 @@ import LoadingPage from "./LoadingPage";
 const CheckerPage = ({ checker, matomoTrackEvent, resetChecker, topic }) => {
   const sessionContext = useContext(SessionContext);
   const { hasIMTR, slug, text } = topic;
+
   // OLO Flow does not have questionIndex
-  const { questionIndex } = hasIMTR ? sessionContext[topic.slug] : 0;
-  const { activeComponents, answers, finishedComponents } = sessionContext[
-    slug
-  ];
+  const { questionIndex = 0 } = sessionContext[slug] || {};
+  const { activeComponents, answers, finishedComponents } =
+    sessionContext[slug] || {};
 
   useEffect(() => {
     // In case no active sections are found, reset the checker
@@ -36,6 +36,7 @@ const CheckerPage = ({ checker, matomoTrackEvent, resetChecker, topic }) => {
     const activeComponent = [
       sections.CONCLUSION,
       sections.LOCATION_INPUT,
+      sections.LOCATION_RESULT,
       sections.QUESTIONS,
     ].find((section) => isActive(section));
 
@@ -55,6 +56,29 @@ const CheckerPage = ({ checker, matomoTrackEvent, resetChecker, topic }) => {
       if (hasIMTR) {
         resetChecker();
       }
+    }
+
+    // Make the app backwards compatible:
+
+    // This section does not exist anymore in the IMTR flow
+    const isOldSectionActive = hasIMTR && isActive(sections.LOCATION_RESULT);
+    const newFinishedComponents = finishedComponents.filter(
+      (section) => section !== sections.LOCATION_INPUT
+    );
+
+    if (isOldSectionActive) {
+      console.warn(
+        "Resetting components, because an old section was found active"
+      );
+
+      // Remove old sections from existing local storage data and set active component to Location Input
+      sessionContext.setSessionData([
+        slug,
+        {
+          activeComponents: [sections.LOCATION_INPUT],
+          finishedComponents: newFinishedComponents,
+        },
+      ]);
     }
 
     // Prevent linter to add all dependencies, now the useEffect is only called on mount

--- a/apps/client/src/pages/CheckerPage.js
+++ b/apps/client/src/pages/CheckerPage.js
@@ -25,7 +25,7 @@ const CheckerPage = ({ checker, matomoTrackEvent, resetChecker, topic }) => {
   const sessionContext = useContext(SessionContext);
   const { hasIMTR, slug, text } = topic;
 
-  // OLO Flow does not have questionIndex
+  // @TODO: replace with custom hooks
   const { questionIndex } = sessionContext[slug] || {};
   const { activeComponents, answers, finishedComponents } =
     sessionContext[slug] || {};

--- a/apps/client/src/pages/CheckerPage.js
+++ b/apps/client/src/pages/CheckerPage.js
@@ -26,7 +26,7 @@ const CheckerPage = ({ checker, matomoTrackEvent, resetChecker, topic }) => {
   const { hasIMTR, slug, text } = topic;
 
   // OLO Flow does not have questionIndex
-  const { questionIndex = 0 } = sessionContext[slug] || {};
+  const { questionIndex } = sessionContext[slug] || {};
   const { activeComponents, answers, finishedComponents } =
     sessionContext[slug] || {};
 


### PR DESCRIPTION
This PR fixes two bugs:
1. Going directly to [LOCATION_RESULT](http://localhost:3030/bouwwerk-slopen/vragen-en-conclusie) in OLO flow broke the app.
2. Refreshing the app on a finished [LOCATION_RESULT](http://localhost:3030/bouwwerk-slopen/vragen-en-conclusie) in OLO flow redirected the user back to the Location Input.
3. Enabling the `LOCATION_RESULT` as a valid active component required the app to be backwards compatible and to "remove old sections from existing local storage data"

Please make sure:
- [x] to add a label
- [x] to add one or more reviewers
- [x] you followed our checklist for [functional testing](https://github.com/Amsterdam/vergunningcheck/blob/master/TESTING.md)
- [x] you added the necessary documentation (either in the markdown files or inline)

Please squash