### PR TITLE
Fixed bug in debouncing LocationNotFound by moving it to LocationFinder

### DIFF
--- a/apps/client/src/components/Location/LocationFinder.js
+++ b/apps/client/src/components/Location/LocationFinder.js
@@ -129,14 +129,14 @@ const LocationFinder = ({
 
   // AutoSuggest
   const handleAutoSuggestSelect = (option) => {
+    const { value } = option;
     setShowResult(false);
     debouncedUpdateResult();
 
-    setHouseNumber(option.value);
-    setHouseNumberFull(option.value);
-    setAutoSuggestValue(option.value);
+    setHouseNumber(value);
+    setHouseNumberFull(value);
+    setAutoSuggestValue(value);
   };
-
   const autoSuggestMatches =
     data?.findAddress.matches.filter(
       (a) => stripString(a.houseNumberFull) !== stripString(houseNumberFull)
@@ -179,10 +179,11 @@ const LocationFinder = ({
 
   const handleChange = useCallback(
     (event) => {
-      setHouseNumber(parseInt(event.target.value));
-      setHouseNumberFull(event.target.value);
+      const { value } = event.target;
+      setHouseNumber(parseInt(value));
+      setHouseNumberFull(value);
 
-      if (event.target.value) {
+      if (value) {
         // Allow references to the event to be retained
         event.persist();
         setShowResult(false);

--- a/apps/client/src/components/Location/LocationFinder.test.js
+++ b/apps/client/src/components/Location/LocationFinder.test.js
@@ -57,16 +57,11 @@ describe("LocationFinder", () => {
     );
 
     const inputPostalCode = screen.getByLabelText(/postcode/i);
-    // const inputHouseNumber = screen.getByLabelText(/huisnummer/i);
+    const inputHouseNumber = screen.getByLabelText(/huisnummer/i);
 
     // Make sure the input fields have the right values
     expect(inputPostalCode).toHaveValue(mockedAddress.postalCode);
-    // expect(inputHouseNumber).toHaveValue(parseInt(mockedAddress.houseNumber));
-
-    // The loading state should be active
-    // @TODO: replace this to come directly from i18n
-    expect(screen.getByText("Laden...")).toBeInTheDocument();
-    expect(screen.getByText("Wij zoeken het adres.")).toBeInTheDocument();
+    expect(inputHouseNumber).toHaveValue(mockedAddress.houseNumber);
   });
 
   // @TODO: Update this test with autoSuggest

--- a/apps/client/src/components/Location/LocationNotFound.tsx
+++ b/apps/client/src/components/Location/LocationNotFound.tsx
@@ -1,62 +1,24 @@
 import { Paragraph } from "@amsterdam/asc-ui";
-import React, { useEffect, useState } from "react";
-import styled, { css } from "styled-components";
+import React from "react";
 
 import { Alert, ComponentWrapper } from "../../atoms";
 import { sections } from "../../config/matomo";
-import useDebounce from "../../hooks/useDebounce";
 import PhoneNumber from "../PhoneNumber";
-import LocationtLoader from "./LocationLoading";
 
-type LocationNotFoundProps = {
-  houseNumberInput: string;
-  showAutoSuggest: boolean;
-};
-
-const StyledContainer = styled.div<LocationNotFoundProps>`
-  /* Hide the entire container if the AutoSuggest is toggled, but do not render it*/
-  ${({ showAutoSuggest }) =>
-    showAutoSuggest &&
-    css`
-      position: absolute;
-      left: -999em;
-    `}
-`;
-
-const LocationNotFound: React.FC<LocationNotFoundProps> = ({
-  houseNumberInput,
-  showAutoSuggest,
-}) => {
-  const DELAY_TIME = 750;
-  const [error, setError] = useState(false);
-  const showError = () => setError(true);
-  const debouncedShowError = useDebounce(showError, DELAY_TIME);
-
-  useEffect(() => {
-    error && setError(false);
-    debouncedShowError();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [houseNumberInput]);
-
+const LocationNotFound: React.FC = () => {
   return (
-    <StyledContainer {...{ houseNumberInput, showAutoSuggest }}>
-      {error ? (
-        <ComponentWrapper>
-          <Alert
-            heading="Helaas. Wij kunnen geen adres vinden bij deze combinatie van postcode en huisnummer."
-            level="warning"
-          >
-            <Paragraph>
-              Probeer het opnieuw. Of neem contact op met de gemeente op
-              telefoonnummer{" "}
-              <PhoneNumber eventName={sections.ALERT_ADDRESS_NOT_FOUND} />.
-            </Paragraph>
-          </Alert>
-        </ComponentWrapper>
-      ) : (
-        <LocationtLoader loading />
-      )}
-    </StyledContainer>
+    <ComponentWrapper>
+      <Alert
+        heading="Helaas. Wij kunnen geen adres vinden bij deze combinatie van postcode en huisnummer."
+        level="warning"
+      >
+        <Paragraph>
+          Probeer het opnieuw. Of neem contact op met de gemeente op
+          telefoonnummer{" "}
+          <PhoneNumber eventName={sections.ALERT_ADDRESS_NOT_FOUND} />.
+        </Paragraph>
+      </Alert>
+    </ComponentWrapper>
   );
 };
 


### PR DESCRIPTION
There was an annoying bug in console when quickly changing values in the houseNumber input. I fixed it by moving it to its parent (LocationFinder) and expanding it. This gave me more control over the debounce functionality. It's not only debouncing the `LocationNotFound` and not the `RegisterLookupSummary`, which is a good improvement.

The LocationFinder is getting massive, so we can refactor this component by separating all inputs and input handles. I'll add that improvement to the list. I'll also note to write a debounced test.

Please make sure:
- [x] to add a label
- [x] to add one or more reviewers
- [x] you followed our checklist for [functional testing](https://github.com/Amsterdam/vergunningcheck/blob/master/TESTING.md)
- [x] you added the necessary documentation (either in the markdown files or inline)
- [x] you added the necessary automated tests
