### PR TITLE
Location e2e test

### DIFF
--- a/apps/e2e/README.md
+++ b/apps/e2e/README.md
@@ -7,7 +7,7 @@ Maybe you also need to run `safaridriver --enable`. I'm not sure.
 
 ## Run the test-suite
 
-`npm test` does the basic test.
+`npm run localhost:test` does the basic test.
 
 Doesn't work yet:
 

--- a/apps/e2e/package-lock.json
+++ b/apps/e2e/package-lock.json
@@ -36,6 +36,11 @@
       "integrity": "sha512-8UT/J+xqCYfn3fKtOznAibsHpiuDshCb0fwgWxRazTT19Igp9ovoXMPhXyLD6m3CKQGTMHgqoxaFfMWaL40Rnw==",
       "dev": true
     },
+    "@types/chai": {
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.13.tgz",
+      "integrity": "sha512-o3SGYRlOpvLFpwJA6Sl1UPOwKFEvE4FxTEB/c9XHI2whdnd4kmPVkNLL8gY4vWGBxWWDumzLbKsAhEH5SKn37Q=="
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -57,6 +62,15 @@
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
       "dev": true
+    },
+    "@types/mkdirp": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-1.0.1.tgz",
+      "integrity": "sha512-HkGSK7CGAXncr8Qn/0VqNtExEE+PHMWb+qlR1faHMao7ng6P3tAaoWWBMdva0gL5h4zprjIO89GJOLXsMcDm1Q==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/node": {
       "version": "14.11.2",
@@ -325,6 +339,37 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
+    "chai": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
+      },
+      "dependencies": {
+        "deep-eql": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+          "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+          "dev": true,
+          "requires": {
+            "type-detect": "^4.0.0"
+          }
+        },
+        "type-detect": {
+          "version": "4.0.8",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+          "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+          "dev": true
+        }
+      }
+    },
     "chai-nightwatch": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/chai-nightwatch/-/chai-nightwatch-0.4.0.tgz",
@@ -364,6 +409,12 @@
           }
         }
       }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
     },
     "chownr": {
       "version": "1.1.4",
@@ -1109,6 +1160,12 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
     "get-stream": {
@@ -2530,6 +2587,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
     },
     "pend": {

--- a/apps/e2e/package.json
+++ b/apps/e2e/package.json
@@ -4,9 +4,9 @@
   "description": "",
   "main": "puppeteer/basic.ts",
   "scripts": {
-    "localhost:test": "run-p test:puppeteer test:nightwatch:*",
+    "localhost:test": "run-p localhost:test:puppeteer localhost:test:nightwatch:*",
     "localhost:test:puppeteer": "ts-node puppeteer/tests/*.ts",
-    "localhost:test:nightwatch": "run-p test:nightwatch:*",
+    "localhost:test:nightwatch": "run-p localhost:test:nightwatch:*",
     "localhost:test:nightwatch:firefox": "kill-port 4444 || : && npx nightwatch nightwatch/tests/*.js -e firefox",
     "localhost:test:nightwatch:chrome": "npx nightwatch nightwatch/tests/*.js -e chrome"
   },

--- a/apps/e2e/package.json
+++ b/apps/e2e/package.json
@@ -4,19 +4,23 @@
   "description": "",
   "main": "puppeteer/basic.ts",
   "scripts": {
-    "test": "run-p test:puppeteer test:nightwatch:*",
-    "test:puppeteer": "ts-node puppeteer/tests/*.ts",
-    "test:nightwatch": "run-p test:nightwatch:*",
-    "test:nightwatch:firefox": "kill-port 4444 || : && npx nightwatch nightwatch/tests/*.js -e firefox",
-    "test:nightwatch:chrome": "npx nightwatch nightwatch/tests/*.js -e chrome"
+    "localhost:test": "run-p test:puppeteer test:nightwatch:*",
+    "localhost:test:puppeteer": "ts-node puppeteer/tests/*.ts",
+    "localhost:test:nightwatch": "run-p test:nightwatch:*",
+    "localhost:test:nightwatch:firefox": "kill-port 4444 || : && npx nightwatch nightwatch/tests/*.js -e firefox",
+    "localhost:test:nightwatch:chrome": "npx nightwatch nightwatch/tests/*.js -e chrome"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "@types/chai": "^4.2.13",
+    "@types/mkdirp": "^1.0.1",
     "@types/puppeteer": "^3.0.2",
+    "chai": "^4.2.0",
     "chromedriver": "^85.0.1",
     "geckodriver": "^1.20.0",
+    "mkdirp": "^1.0.4",
     "nightwatch": "^1.4.3",
     "npm-run-all": "^4.1.5",
     "puppeteer": "^5.3.1",

--- a/apps/e2e/puppeteer/config.ts
+++ b/apps/e2e/puppeteer/config.ts
@@ -1,7 +1,8 @@
 import { Flow } from "./types";
 
 // export const host = "https://vergunningcheck.amsterdam.nl/test";
-export const host = "https://ux.chappie2.com";
+// export const host = "https://ux.chappie2.com";
+export const host = "http://localhost:3000";
 
 export const DEBUG = false;
 

--- a/apps/e2e/puppeteer/config.ts
+++ b/apps/e2e/puppeteer/config.ts
@@ -1,0 +1,32 @@
+import { Flow } from "./types";
+
+// export const host = "https://vergunningcheck.amsterdam.nl/test";
+export const host = "https://ux.chappie2.com";
+
+export const DEBUG = false;
+
+export const puppeteerOptions = DEBUG ? {
+  headless: false, slowMo: 150
+} : {};
+
+export const address = {
+  zipCode: '1043ap',
+  houseNumberFull: '30',
+}
+
+export const flows: Flow[] = [
+  {
+    type: 'olo',
+    options: {
+      shouldAlwaysDisplayMonumentStatus: true,
+    },
+    checkers: ["aanbouw-of-uitbouw-maken", "bouwwerk-slopen", "intern-verbouwen"],
+  },
+  {
+    type: 'imtr',
+    options: {
+      shouldAlwaysDisplayMonumentStatus: false,
+    },
+    checkers: ["dakkapel-plaatsen", "dakraam-plaatsen", "kozijnen-plaatsen", "zonnepanelen-of-zonneboiler-plaatsen", "zonwering-of-rolluik-plaatsen"],
+  }
+];

--- a/apps/e2e/puppeteer/tests/basic.ts
+++ b/apps/e2e/puppeteer/tests/basic.ts
@@ -1,11 +1,12 @@
 import puppeteer from "puppeteer";
+import { host } from "../config";
 
 const path = "build/example.png";
 
 (async () => {
   const browser = await puppeteer.launch();
   const page = await browser.newPage();
-  await page.goto("https://vergunningcheck.amsterdam.nl/test");
+  await page.goto(host);
   console.log('done rendering chappie')
   await page.screenshot({ path });
   console.log('saved screenshot in ', path)

--- a/apps/e2e/puppeteer/tests/location-component.ts
+++ b/apps/e2e/puppeteer/tests/location-component.ts
@@ -1,0 +1,46 @@
+import { expect } from 'chai';
+import puppeteer from "puppeteer";
+import { flows, host, puppeteerOptions, address } from "../config";
+import { FlowOptions } from "../types";
+
+// @TODO actually click in dropdown
+// await page.type('[name="houseNumber"]', '19');
+// await page.click('[data-testid="suggestList"] a');
+
+const testFlow = async (page: puppeteer.Page, options: FlowOptions) => {
+
+  await page.waitForSelector('[data-testid="next-button"]');
+  await page.click('[data-testid="next-button"]');
+
+  await page.waitForSelector('[name="postalCode"]');
+  await page.type('[name="postalCode"]', address.zipCode);
+  await page.type('[name="houseNumber"]', address.houseNumberFull);
+
+  await page.waitForSelector('[data-testid="location-found"]', { visible: true });
+
+  if (options.shouldAlwaysDisplayMonumentStatus) {
+    const monument = await page.$eval('[data-testid="restriction-monument"]', el => el.textContent);
+    expect(monument).to.include('Het gebouw is geen monument.');
+
+    const cityscape = await page.$eval('[data-testid="restriction-cityscape"]', el => el.textContent);
+    expect(cityscape).to.include('Het gebouw ligt niet in een beschermd stads- of dorpsgezicht.');
+  } else {
+    expect((await page.$$('[data-testid="restriction-monument"]')).length).to.equal(0);
+    expect((await page.$$('[data-testid="restriction-cityscape"]')).length).to.equal(0);
+  }
+}
+
+flows.forEach(async (flow) => {
+  flow.checkers.forEach(async (url) => {
+    const browser = await puppeteer.launch(puppeteerOptions);
+    try {
+      const page = await browser.newPage();
+      await page.goto(`${host}/${url}`);
+      await testFlow(page, flow.options);
+    } catch (e) {
+      console.error(e);
+    } finally {
+      await browser.close();
+    }
+  })
+})

--- a/apps/e2e/puppeteer/types.ts
+++ b/apps/e2e/puppeteer/types.ts
@@ -1,0 +1,11 @@
+export type Slug = string;
+
+export type Flow = {
+  options: FlowOptions;
+  type: 'olo' | 'imtr';
+  checkers: Slug[]
+}
+
+export type FlowOptions = {
+  shouldAlwaysDisplayMonumentStatus: boolean;
+}

--- a/apps/e2e/puppeteer/util.ts
+++ b/apps/e2e/puppeteer/util.ts
@@ -1,0 +1,14 @@
+import puppeteer from "puppeteer";
+import mkdirp from "mkdirp";
+
+const folder = `build/${new Date()}`;
+
+(async () => {
+  await mkdirp(folder);
+})();
+
+export const screenshot = async (page: puppeteer.Page) => {
+  const path = `${folder}/${new Date()}.png`;
+  await page.screenshot({ path });
+  console.log('saved screenshot in ', path);
+}


### PR DESCRIPTION
Added puppeteer e2e-test for new location component.
Disable `npm test` and make it localhost-only (for now) to prevent false assumption everything works, while actually testing the ux/acc env.
Added some files to make testing in puppeteer more easy.