### PR TITLE
Fix broken e2e tests

### DIFF
--- a/apps/client/src/components/Location/LocationFinder.js
+++ b/apps/client/src/components/Location/LocationFinder.js
@@ -230,7 +230,7 @@ const LocationFinder = ({
           }
           id="houseNumberFull"
           label="Huisnummer + toevoeging"
-          name="houseNumber"
+          name="houseNumberFull"
           onBlur={handleBlur}
           onChange={handleChange}
           onFocus={() => setFocus(true)}

--- a/apps/e2e/nightwatch/tests/oloFlow.js
+++ b/apps/e2e/nightwatch/tests/oloFlow.js
@@ -37,7 +37,6 @@ module.exports = {
     b.click(navButtonNext);
     b.waitForElementVisible(navButtonPrev);
     b.click(navButtonPrev);
-    b.click(navButtonPrev); // BUG: click 2 times; issue in ui bothering user the zip-code field is invalid
     assert.containsText(
       main,
       "U gebruikt deze informatie om de vergunningcheck te doen op het Omgevingsloket."


### PR DESCRIPTION
This PR fixes broken e2e tests (for the new location branch) by renaming the input field back to `houseNumberFull` and by removing the fix for double input clicks

