### PR TITLE
Fixed bug when showing result that wasn't a true exactMatch

### DIFF
--- a/apps/client/src/components/Location/LocationFinder.js
+++ b/apps/client/src/components/Location/LocationFinder.js
@@ -19,6 +19,10 @@ const postalCodeRegex = /^[1-9][0-9]{3}[\s]?[A-Za-z]{2}$/i;
 
 const RESULT_DELAY = 750;
 
+const isTrueExactMatch = (match, houseNumberFull) =>
+  houseNumberFull &&
+  stripString(match?.houseNumberFull) === stripString(houseNumberFull);
+
 const LocationFinder = ({
   focus,
   matomoTrackEvent,
@@ -112,6 +116,9 @@ const LocationFinder = ({
 
   const exactMatch = data?.findAddress?.exactMatch;
 
+  // This make sures the exactMatch is equal to the user input
+  const isExactMatch = isTrueExactMatch(exactMatch, houseNumberFull);
+
   // Prevent setState error
   useEffect(() => {
     setErrorMessage(graphqlError);
@@ -155,13 +162,13 @@ const LocationFinder = ({
   }));
 
   // Determine when to show components
-  const showExactMatch = exactMatch && !loading;
+  const showExactMatch = isExactMatch && !loading;
 
   const showLocationNotFound = !!(
     houseNumberFull &&
     isValidPostalcode(postalCode) &&
     showResult &&
-    !exactMatch &&
+    !isExactMatch &&
     !loading &&
     !graphqlError &&
     !showAutoSuggest

--- a/apps/client/src/components/Location/LocationFinder.tsx
+++ b/apps/client/src/components/Location/LocationFinder.tsx
@@ -19,6 +19,13 @@ const postalCodeRegex = /^[1-9][0-9]{3}[\s]?[A-Za-z]{2}$/i;
 
 const RESULT_DELAY = 750;
 
+const isTrueExactMatch = (
+  match?: { houseNumberFull?: string },
+  houseNumberFull?: string
+) =>
+  houseNumberFull &&
+  stripString(match?.houseNumberFull) === stripString(houseNumberFull);
+
 const LocationFinder: React.FC<{
   focus: boolean;
   matomoTrackEvent: Function;
@@ -126,6 +133,9 @@ const LocationFinder: React.FC<{
 
   const exactMatch = data?.findAddress?.exactMatch;
 
+  // This make sures the exactMatch is equal to the user input
+  const isExactMatch = isTrueExactMatch(exactMatch, houseNumberFull);
+
   // Prevent setState error
   useEffect(() => {
     setErrorMessage(graphqlError);
@@ -172,13 +182,13 @@ const LocationFinder: React.FC<{
   );
 
   // Determine when to show components
-  const showExactMatch = exactMatch && !loading;
+  const showExactMatch = isExactMatch && !loading;
 
   const showLocationNotFound = !!(
     houseNumberFull &&
     isValidPostalcode(postalCode) &&
     showResult &&
-    !exactMatch &&
+    !isExactMatch &&
     !loading &&
     !graphqlError &&
     !showAutoSuggest


### PR DESCRIPTION
Fixed bug when showing result that wasn't a true exactMatch. See [trello card](https://trello.com/c/XeOv9IaP/156-een-huisnummer-met-%C3%A9%C3%A9n-toevoeging-geeft-gelijk-dit-resultaat)

![image](https://user-images.githubusercontent.com/7781865/95477803-05f45400-0989-11eb-8c9b-2a7385090f74.png)
