### PR TITLE
Fixed titles, styling and tests for RegistryLookupSummary

### DIFF
--- a/apps/client/src/__mocks__/addressMockNoRestrictions.ts
+++ b/apps/client/src/__mocks__/addressMockNoRestrictions.ts
@@ -1,0 +1,12 @@
+export default {
+  houseNumberFull: "123",
+  postalCode: "1234 AB",
+  residence: "Amsterdam",
+  restrictions: [],
+  streetName: "streetname",
+  zoningPlans: [
+    {
+      name: "zoningplan",
+    },
+  ],
+};

--- a/apps/client/src/atoms/List.ts
+++ b/apps/client/src/atoms/List.ts
@@ -1,7 +1,8 @@
-import { List, themeSpacing } from "@amsterdam/asc-ui";
+import { List, breakpoint, themeSpacing } from "@amsterdam/asc-ui";
 import styled, { css } from "styled-components";
 
 type Props = {
+  compactThemeSpacing?: boolean;
   noPadding?: boolean;
 };
 
@@ -14,5 +15,18 @@ export default styled(List)<Props>`
     !noPadding &&
     css`
       padding-left: ${themeSpacing(5)};
+    `}
+
+  ${({ compactThemeSpacing }) =>
+    // Without the `<CompactThemeSpacing />` the default font-size is 18px on larger screens
+    // with the `compactThemeSpacing` prop you can make the fonts equal, eg: Alert
+    compactThemeSpacing &&
+    css`
+      @media ${breakpoint("min-width", "tabletS")} {
+        li {
+          font-size: 16px;
+          line-height: 20px;
+        }
+      }
     `}
 `;

--- a/apps/client/src/components/Location/LocationFinder.tsx
+++ b/apps/client/src/components/Location/LocationFinder.tsx
@@ -292,8 +292,9 @@ const LocationFinder: React.FC<{
               </Paragraph>
               <RegisterLookupSummary
                 addressFromLocation={exactMatch}
-                compact
+                isBelowInputFields
                 matomoTrackEvent={matomoTrackEvent}
+                showTitle
                 topic={topic}
               />
             </Alert>

--- a/apps/client/src/components/Location/LocationResult.tsx
+++ b/apps/client/src/components/Location/LocationResult.tsx
@@ -47,6 +47,7 @@ const LocationResult: React.FC<LocationResultProps> = ({
     <Form data-testid={LOCATION_RESULT} onSubmit={onSubmit}>
       <Heading forwardedAs="h3">Adresgegevens</Heading>
       <RegisterLookupSummary
+        showTitle
         {...{
           setActiveState,
           topic,

--- a/apps/client/src/components/RegisterLookupSummary.test.js
+++ b/apps/client/src/components/RegisterLookupSummary.test.js
@@ -1,15 +1,11 @@
 import React from "react";
 
 import addressMock from "../__mocks__/addressMock";
-import addressMockNoCityScape from "../__mocks__/addressMockNoCityScape";
-import addressMockNoMonument from "../__mocks__/addressMockNoMonument";
+import addressMockNoRestrictions from "../__mocks__/addressMockNoRestrictions";
 import Context from "../__mocks__/context";
-import matchMedia from "../__mocks__/matchMedia";
 import { findTopicBySlug } from "../utils";
-import { act, fireEvent, render, screen } from "../utils/test-utils";
+import { render, screen } from "../utils/test-utils";
 import RegisterLookupSummary from "./RegisterLookupSummary";
-
-Object.defineProperty(window, "matchMedia", matchMedia);
 
 jest.mock("react-router-dom", () => ({
   useParams: () => ({ slug: "dakkapel-plaatsen" }),
@@ -28,146 +24,237 @@ describe("RegisterLookupSummary", () => {
     );
   };
 
-  it("renders correctly in STTR Flow if monument and national cityScape", () => {
+  it("renders in STTR Flow on LocationFinder (with all restrictions)", () => {
     const topicMock = "dakraam-plaatsen";
     const topic = findTopicBySlug(topicMock);
-    const { queryByText } = render(<WrapperWithContext topic={topic} />);
+    render(<WrapperWithContext isBelowInputFields showTitle topic={topic} />);
 
-    expect(queryByText("Het gebouw is een monument.")).toBeInTheDocument();
+    // Expext to find:
     expect(
-      queryByText(
-        "Het gebouw ligt in een rijksbeschermd stads- of dorpsgezicht."
-      )
+      screen.queryByText("Het gebouw is een monument.")
     ).toBeInTheDocument();
 
-    // Expect NOT to find zoningplan info
-    expect(queryByText("zoningplan")).not.toBeInTheDocument();
-    expect(screen.queryByText(/wijzig/i)).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        "Het gebouw ligt in een rijksbeschermd stads- of dorpsgezicht.",
+        { exact: false }
+      )
+    ).toBeInTheDocument(); // Beware: it should find the result: "has national cityscape"
 
-    act(() => {
-      fireEvent.click(screen.queryByText(/wijzig/i));
-    });
+    // Expect NOT to find:
+    expect(screen.queryByText(/wijzig/i)).not.toBeInTheDocument();
+
+    expect(screen.queryByText("zoningplan")).not.toBeInTheDocument();
   });
 
-  it("renders correctly in STTR Flow if no cityScape", () => {
+  it("renders in STTR Flow on LocationFinder (without any restrictions)", () => {
     const topicMock = "dakraam-plaatsen";
     const topic = findTopicBySlug(topicMock);
-    const { queryByText } = render(
+    render(
       <WrapperWithContext
-        addressFromLocation={addressMockNoCityScape}
+        addressFromLocation={addressMockNoRestrictions}
+        isBelowInputFields
+        showTitle
         topic={topic}
       />
     );
 
+    // Expect NOT to find:
     expect(
-      queryByText("beschermd stads- of dorpsgezicht.")
+      screen.queryByText("Het gebouw is een monument.")
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.queryByText("Het gebouw is geen monument.")
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.queryByText("stads- of dorpsgezicht.", { exact: false })
+    ).not.toBeInTheDocument();
+
+    expect(screen.queryByText(/wijzig/i)).not.toBeInTheDocument();
+
+    expect(screen.queryByText("zoningplan")).not.toBeInTheDocument();
+  });
+
+  it("renders in STTR Flow above the questionnaire (with all restrictions)", () => {
+    const topicMock = "dakraam-plaatsen";
+    const topic = findTopicBySlug(topicMock);
+    render(<WrapperWithContext showEditLocationModal topic={topic} />);
+
+    // Expext to find:
+    expect(
+      screen.queryByText("Het gebouw is een monument.")
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByText(
+        "Het gebouw ligt in een rijksbeschermd stads- of dorpsgezicht.",
+        { exact: false }
+      )
+    ).toBeInTheDocument(); // Beware: it should find the result: "has national cityscape"
+
+    expect(screen.queryByText(/wijzig/i)).toBeInTheDocument();
+
+    // Expect NOT to find:
+    expect(screen.queryByText("zoningplan")).not.toBeInTheDocument();
+  });
+
+  it("renders in STTR Flow above the questionnaire (without any restrictions)", () => {
+    const topicMock = "dakraam-plaatsen";
+    const topic = findTopicBySlug(topicMock);
+    render(
+      <WrapperWithContext
+        addressFromLocation={addressMockNoRestrictions}
+        showEditLocationModal
+        topic={topic}
+      />
+    );
+
+    // Expext to find:
+    expect(screen.queryByText(/wijzig/i)).toBeInTheDocument();
+
+    // Expect NOT to find:
+    expect(
+      screen.queryByText("Het gebouw is een monument.")
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.queryByText("Het gebouw is geen monument.")
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.queryByText("stads- of dorpsgezicht.", { exact: false })
+    ).not.toBeInTheDocument();
+
+    expect(screen.queryByText("zoningplan")).not.toBeInTheDocument();
+  });
+
+  /**
+   *
+   * OLO FLOW START HERE:
+   *
+   */
+
+  it("renders in OLO Flow on LocationFinder (with all restrictions)", () => {
+    const topicMock = "aanbouw-of-uitbouw-maken";
+    const topic = findTopicBySlug(topicMock);
+    render(
+      <WrapperWithContext
+        addressFromLocation={addressMock}
+        isBelowInputFields
+        showTitle
+        topic={topic}
+      />
+    );
+
+    // Expext to find:
+    expect(
+      screen.queryByText("Het gebouw is een monument.")
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByText(
+        "Het gebouw ligt in een rijksbeschermd stads- of dorpsgezicht.",
+        { exact: false }
+      )
+    ).toBeInTheDocument(); // Beware: it should find the result: "has national cityscape"
+
+    // Expect NOT to find:
+    expect(screen.queryByText(/wijzig/i)).not.toBeInTheDocument();
+
+    expect(screen.queryByText("zoningplan")).not.toBeInTheDocument();
+  });
+
+  it("renders in OLO Flow on LocationFinder (without any restrictions)", () => {
+    const topicMock = "aanbouw-of-uitbouw-maken";
+    const topic = findTopicBySlug(topicMock);
+    render(
+      <WrapperWithContext
+        addressFromLocation={addressMockNoRestrictions}
+        isBelowInputFields
+        showTitle
+        topic={topic}
+      />
+    );
+
+    // Expect to find:
+    expect(
+      screen.queryByText("Het gebouw is geen monument.")
+    ).toBeInTheDocument(); // Beware: it should find the result: "no monument"
+
+    expect(
+      screen.queryByText(
+        "Het gebouw ligt niet in een beschermd stads- of dorpsgezicht.",
+        { exact: false }
+      )
+    ).toBeInTheDocument(); // Beware: it should find the result: "no cityscape"
+
+    // Expect NOT to find:
+    expect(screen.queryByText(/wijzig/i)).not.toBeInTheDocument();
+
+    expect(screen.queryByText("zoningplan")).not.toBeInTheDocument();
+  });
+
+  it("renders in OLO Flow on the Results Page (with all restrictions)", () => {
+    const topicMock = "aanbouw-of-uitbouw-maken";
+    const topic = findTopicBySlug(topicMock);
+    render(
+      <WrapperWithContext
+        addressFromLocation={addressMock}
+        showTitle
+        topic={topic}
+      />
+    );
+
+    // Expext to find:
+    expect(
+      screen.queryByText("Het gebouw is een monument.")
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByText(
+        "Het gebouw ligt in een rijksbeschermd stads- of dorpsgezicht.",
+        { exact: false }
+      )
+    ).toBeInTheDocument(); // Beware: it should find the result: "has national cityscape"
+
+    expect(screen.queryByText("zoningplan")).toBeInTheDocument();
+
+    // Expect NOT to find:
+    expect(screen.queryByText(/wijzig/i)).not.toBeInTheDocument();
+  });
+
+  it("renders in OLO Flow on the Results Page (without any restrictions)", () => {
+    const topicMock = "aanbouw-of-uitbouw-maken";
+    const topic = findTopicBySlug(topicMock);
+    render(
+      <WrapperWithContext
+        addressFromLocation={addressMockNoRestrictions}
+        showTitle
+        topic={topic}
+      />
+    );
+
+    // Expext to find:
+    expect(screen.queryByText("zoningplan")).toBeInTheDocument();
+
+    expect(
+      screen.queryByText("Het gebouw is geen monument.")
+    ).toBeInTheDocument(); // Beware: it should find the result: "no monument"
+
+    expect(
+      screen.queryByText(
+        "Het gebouw ligt niet in een beschermd stads- of dorpsgezicht.",
+        { exact: false }
+      )
+    ).toBeInTheDocument(); // Beware: it should find the result: "no cityscape"
+
+    // Expect NOT to find:
+    expect(screen.queryByText(/wijzig/i)).not.toBeInTheDocument();
+
+    expect(
+      screen.queryByText("Het gebouw is een monument.")
     ).not.toBeInTheDocument();
   });
-
-  it("renders correctly in STTR Flow if NOT a monument and municipal cityScape", () => {
-    const topicMock = "dakraam-plaatsen";
-    const topic = findTopicBySlug(topicMock);
-    const { queryByText } = render(
-      <WrapperWithContext
-        addressFromLocation={addressMockNoMonument}
-        topic={topic}
-      />
-    );
-
-    expect(queryByText("Het gebouw is een monument.")).not.toBeInTheDocument();
-    expect(
-      queryByText(
-        "Het gebouw ligt in een gemeentelijk beschermd stads- of dorpsgezicht."
-      )
-    ).toBeInTheDocument();
-
-    // Expect NOT to find zoningplan info
-    expect(queryByText("zoningplan")).not.toBeInTheDocument();
-
-    expect(screen.queryByText(/wijzig/i)).toBeInTheDocument();
-
-    act(() => {
-      fireEvent.click(screen.queryByText(/wijzig/i));
-    });
-  });
-
-  it("renders correctly in OLO Flow if no cityScape", () => {
-    const topicMock = "aanbouw-of-uitbouw-maken";
-    const topic = findTopicBySlug(topicMock);
-    const { queryByText } = render(
-      <WrapperWithContext
-        addressFromLocation={addressMockNoCityScape}
-        topic={topic}
-      />
-    );
-
-    expect(
-      queryByText(
-        "Het gebouw ligt niet in een beschermd stads- of dorpsgezicht."
-      )
-    ).toBeInTheDocument();
-  });
-
-  it("renders correctly in OLO Flow if building is a monument and national cityScape", () => {
-    const topicMock = "aanbouw-of-uitbouw-maken";
-    const topic = findTopicBySlug(topicMock);
-    const { queryByText } = render(
-      <WrapperWithContext addressFromLocation={addressMock} topic={topic} />
-    );
-
-    expect(queryByText("Het gebouw is een monument.")).toBeInTheDocument();
-    expect(
-      queryByText(
-        "Het gebouw ligt in een rijksbeschermd stads- of dorpsgezicht."
-      )
-    ).toBeInTheDocument();
-
-    // Expect to find zoningplan info
-    expect(queryByText("zoningplan")).toBeInTheDocument();
-
-    expect(screen.queryByText(/wijzig/i)).not.toBeInTheDocument();
-  });
-
-  it("renders correctly in OLO Flow if building is NOT a monument and a MUNICIPAL cityScape", () => {
-    const topicMock = "aanbouw-of-uitbouw-maken";
-    const topic = findTopicBySlug(topicMock);
-    const { queryByText } = render(
-      <WrapperWithContext
-        addressFromLocation={addressMockNoMonument}
-        topic={topic}
-      />
-    );
-    expect(queryByText("Het gebouw is geen monument.")).toBeInTheDocument();
-    expect(
-      queryByText(
-        "Het gebouw ligt in een gemeentelijk beschermd stads- of dorpsgezicht."
-      )
-    ).toBeInTheDocument();
-
-    // Expect to find zoningplan info
-    expect(queryByText("zoningplan")).toBeInTheDocument();
-
-    expect(screen.queryByText(/wijzig/i)).not.toBeInTheDocument();
-  });
-
-  it("renders correctly in address from location object", () => {
-    const setActiveState = jest.fn();
-    const topicMock = "aanbouw-of-uitbouw-maken";
-    const topic = findTopicBySlug(topicMock);
-
-    const { queryByText } = render(
-      <RegisterLookupSummary
-        addressFromLocation={addressMock}
-        setActiveState={setActiveState}
-        topic={topic}
-      />
-    );
-
-    // Expect TO DO find zoningplan info
-    expect(queryByText("zoningplan")).toBeInTheDocument();
-
-    expect(screen.queryByText(/wijzig/i)).not.toBeInTheDocument();
-  });
-
-  // @TODO: finish this test when we work on the Location Component
 });

--- a/apps/client/src/components/RegisterLookupSummary.tsx
+++ b/apps/client/src/components/RegisterLookupSummary.tsx
@@ -129,8 +129,7 @@ const RegisterLookupSummary: React.FC<RegisterLookupSummaryProps> = ({
                 ? `Het gebouw ligt in een ${
                     cityScape === "NATIONAL"
                       ? "rijksbeschermd"
-                      : // istanbul ignore next
-                        "gemeentelijk beschermd"
+                      : "gemeentelijk beschermd"
                   } stads- of dorpsgezicht.`
                 : `Het gebouw ligt niet in een beschermd stads- of dorpsgezicht.`}
             </StyledListItem>
@@ -143,22 +142,19 @@ const RegisterLookupSummary: React.FC<RegisterLookupSummaryProps> = ({
           <Paragraph gutterBottom={8} strong>
             Bestemmingsplannen:
           </Paragraph>
-          {
-            //istanbul ignore next
-            zoningPlanNames.length === 0 ? (
-              <Paragraph>Geen bestemmingsplannen</Paragraph>
-            ) : (
-              <StyledList
-                data-testid={LOCATION_ZONING_PLANS}
-                noPadding
-                variant="bullet"
-              >
-                {zoningPlanNames.map((planName: string) => (
-                  <StyledListItem key={planName}>{planName}</StyledListItem>
-                ))}
-              </StyledList>
-            )
-          }
+          {zoningPlanNames.length === 0 ? (
+            <Paragraph>Geen bestemmingsplannen</Paragraph>
+          ) : (
+            <StyledList
+              data-testid={LOCATION_ZONING_PLANS}
+              noPadding
+              variant="bullet"
+            >
+              {zoningPlanNames.map((planName: string) => (
+                <StyledListItem key={planName}>{planName}</StyledListItem>
+              ))}
+            </StyledList>
+          )}
         </>
       )}
     </ComponentWrapper>

--- a/apps/client/src/pages/CheckerPage.js
+++ b/apps/client/src/pages/CheckerPage.js
@@ -242,6 +242,7 @@ const CheckerPage = ({ checker, matomoTrackEvent, resetChecker, topic }) => {
             )}
             {!isActive(sections.LOCATION_INPUT) && (
               <RegisterLookupSummary
+                showEditLocationModal
                 {...{
                   matomoTrackEvent,
                   resetChecker,

--- a/apps/client/src/utils/test-ids.js
+++ b/apps/client/src/utils/test-ids.js
@@ -22,6 +22,7 @@ export const INTRO_EXCEPTION_BULLETS = "intro-exception-bullets";
 export const LOCATION_FOUND = "location-found";
 export const LOCATION_RESTRICTION_CITYSCAPE = "restriction-cityscape";
 export const LOCATION_RESTRICTION_MONUMENT = "restriction-monument";
+export const LOCATION_SUMMARY = "location-summary";
 export const LOCATION_RESULT = "address-form";
 export const LOCATION_ZONING_PLANS = "zoning-plans";
 export const RADIO_ADDRESS_1 = "address-input-1";


### PR DESCRIPTION
Fixes Trello cards [1](https://trello.com/c/VUW0X8EH/1553-ontbrekende-witruimte-en-titel-tussen-adres-en-locatie-meta-gegevens) and [2](https://trello.com/c/SnzwYMnC/1554-onduidelijke-afstanden-tussen-monument-en-stadsgezicht). RegistryLookupSummary also has 100% test coverage now.

Please make sure:
- [x] to add a label
- [x] to add one or more reviewers
- [x] you followed our checklist for [functional testing](https://github.com/Amsterdam/vergunningcheck/blob/master/TESTING.md)
- [x] you added the necessary documentation (either in the markdown files or inline)
- [x] you added the necessary automated tests

## Looks like this in STTR:
![image](https://user-images.githubusercontent.com/7781865/95876973-ef2c7380-0d73-11eb-9070-74baed78be54.png)

![image](https://user-images.githubusercontent.com/7781865/95876932-e5a30b80-0d73-11eb-880b-0c1b0f199400.png)


## Looks like this in OLO:
![image](https://user-images.githubusercontent.com/7781865/95877041-010e1680-0d74-11eb-853e-0164403a79bd.png)

![image](https://user-images.githubusercontent.com/7781865/95877020-fc496280-0d73-11eb-9c68-475da1c92782.png)
