### PR TITLE
Fixed bug displaying the Location Summary

### DIFF
--- a/apps/client/src/__mocks__/addressMockNoZoningplans.ts
+++ b/apps/client/src/__mocks__/addressMockNoZoningplans.ts
@@ -1,0 +1,14 @@
+export default {
+  houseNumberFull: "123",
+  postalCode: "1234 AB",
+  residence: "Amsterdam",
+  restrictions: [
+    {
+      __typename: "CityScape",
+      name: "cityscape",
+      scope: "MUNICIPAL",
+    },
+  ],
+  streetName: "streetname",
+  zoningPlans: [],
+};

--- a/apps/client/src/components/RegisterLookupSummary.test.js
+++ b/apps/client/src/components/RegisterLookupSummary.test.js
@@ -1,7 +1,9 @@
 import React from "react";
 
 import addressMock from "../__mocks__/addressMock";
+import addressMockNoMonument from "../__mocks__/addressMockNoMonument";
 import addressMockNoRestrictions from "../__mocks__/addressMockNoRestrictions";
+import addressMockNoZoningplans from "../__mocks__/addressMockNoZoningplans";
 import Context from "../__mocks__/context";
 import { findTopicBySlug } from "../utils";
 import { render, screen } from "../utils/test-utils";
@@ -39,9 +41,43 @@ describe("RegisterLookupSummary", () => {
         "Het gebouw ligt in een rijksbeschermd stads- of dorpsgezicht.",
         { exact: false }
       )
-    ).toBeInTheDocument(); // Beware: it should find the result: "has national cityscape"
+    ).toBeInTheDocument(); // Beware: it should find the result: "has NATIONAL cityscape"
 
     // Expect NOT to find:
+    expect(screen.queryByText(/wijzig/i)).not.toBeInTheDocument();
+
+    expect(screen.queryByText("zoningplan")).not.toBeInTheDocument();
+  });
+
+  it("renders in STTR Flow on LocationFinder (with selected restrictions)", () => {
+    const topicMock = "dakraam-plaatsen";
+    const topic = findTopicBySlug(topicMock);
+    render(
+      <WrapperWithContext
+        addressFromLocation={addressMockNoMonument}
+        isBelowInputFields
+        showTitle
+        topic={topic}
+      />
+    );
+
+    // Expext to find:
+    expect(
+      screen.queryByText(
+        "Het gebouw ligt in een gemeentelijk beschermd stads- of dorpsgezicht.",
+        { exact: false }
+      )
+    ).toBeInTheDocument(); // Beware: it should find the result: "has MUNICIPAL cityscape"
+
+    // Expect NOT to find:
+    expect(
+      screen.queryByText("Het gebouw is geen monument.")
+    ).not.toBeInTheDocument(); // Beware: it should NOT find the result: "no monument"
+
+    expect(
+      screen.queryByText("Het gebouw is een monument.")
+    ).not.toBeInTheDocument(); // Beware: it should NOT find the result: "a monument"
+
     expect(screen.queryByText(/wijzig/i)).not.toBeInTheDocument();
 
     expect(screen.queryByText("zoningplan")).not.toBeInTheDocument();
@@ -92,11 +128,48 @@ describe("RegisterLookupSummary", () => {
         "Het gebouw ligt in een rijksbeschermd stads- of dorpsgezicht.",
         { exact: false }
       )
-    ).toBeInTheDocument(); // Beware: it should find the result: "has national cityscape"
+    ).toBeInTheDocument(); // Beware: it should find the result: "has NATIONAL cityscape"
 
     expect(screen.queryByText(/wijzig/i)).toBeInTheDocument();
 
     // Expect NOT to find:
+    expect(screen.queryByText("zoningplan")).not.toBeInTheDocument();
+  });
+
+  it("renders in STTR Flow above the questionnaire (with selected restrictions)", () => {
+    const topicMock = "dakraam-plaatsen";
+    const topic = findTopicBySlug(topicMock);
+    render(
+      <WrapperWithContext
+        addressFromLocation={addressMockNoMonument}
+        showEditLocationModal
+        topic={topic}
+      />
+    );
+
+    // Expext to find:
+    expect(screen.queryByText(/wijzig/i)).toBeInTheDocument();
+
+    expect(
+      screen.queryByText(
+        "Het gebouw ligt in een gemeentelijk beschermd stads- of dorpsgezicht.",
+        { exact: false }
+      )
+    ).toBeInTheDocument(); // Beware: it should find the result: "has MUNICIPAL cityscape"
+
+    // Expect NOT to find:
+    expect(
+      screen.queryByText("Het gebouw is geen monument.")
+    ).not.toBeInTheDocument(); // Beware: it should NOT find the result: "no monument"
+
+    expect(
+      screen.queryByText("Het gebouw is een monument.")
+    ).not.toBeInTheDocument(); // Beware: it should NOT find the result: "a monument"
+
+    expect(
+      screen.queryByText("Het gebouw is een monument.")
+    ).not.toBeInTheDocument(); // Beware: it should NOT find the result: "a monument"
+
     expect(screen.queryByText("zoningplan")).not.toBeInTheDocument();
   });
 
@@ -158,7 +231,7 @@ describe("RegisterLookupSummary", () => {
         "Het gebouw ligt in een rijksbeschermd stads- of dorpsgezicht.",
         { exact: false }
       )
-    ).toBeInTheDocument(); // Beware: it should find the result: "has national cityscape"
+    ).toBeInTheDocument(); // Beware: it should find the result: "has NATIONAL cityscape"
 
     // Expect NOT to find:
     expect(screen.queryByText(/wijzig/i)).not.toBeInTheDocument();
@@ -217,7 +290,7 @@ describe("RegisterLookupSummary", () => {
         "Het gebouw ligt in een rijksbeschermd stads- of dorpsgezicht.",
         { exact: false }
       )
-    ).toBeInTheDocument(); // Beware: it should find the result: "has national cityscape"
+    ).toBeInTheDocument(); // Beware: it should find the result: "has NATIONAL cityscape"
 
     expect(screen.queryByText("zoningplan")).toBeInTheDocument();
 
@@ -256,5 +329,20 @@ describe("RegisterLookupSummary", () => {
     expect(
       screen.queryByText("Het gebouw is een monument.")
     ).not.toBeInTheDocument();
+  });
+
+  it("renders in OLO Flow on the Results Page (without any zoningplans)", () => {
+    const topicMock = "aanbouw-of-uitbouw-maken";
+    const topic = findTopicBySlug(topicMock);
+    render(
+      <WrapperWithContext
+        addressFromLocation={addressMockNoZoningplans}
+        showTitle
+        topic={topic}
+      />
+    );
+
+    // Expect NOT to find:
+    expect(screen.queryByText("zoningplan")).not.toBeInTheDocument();
   });
 });

--- a/apps/client/src/components/RegisterLookupSummary.tsx
+++ b/apps/client/src/components/RegisterLookupSummary.tsx
@@ -116,14 +116,14 @@ const RegisterLookupSummary: React.FC<RegisterLookupSummaryProps> = ({
           noPadding
           variant="bullet"
         >
-          {(monument || showSummary) && (
+          {(monument || !hasIMTR) && (
             <StyledListItem data-testid={LOCATION_RESTRICTION_MONUMENT}>
               {monument
                 ? `Het gebouw is een ${monument.toLowerCase()}.`
                 : "Het gebouw is geen monument."}
             </StyledListItem>
           )}
-          {(cityScape || showSummary) && (
+          {(cityScape || !hasIMTR) && (
             <StyledListItem data-testid={LOCATION_RESTRICTION_CITYSCAPE}>
               {cityScape
                 ? `Het gebouw ligt in een ${


### PR DESCRIPTION
There was a small bug in displaying the wrong data in the Location Summary. Also the test coverage has been 100% without any `istanbul`. Thanks @afjlambert 

Please make sure:
- [x] to add a label
- [x] to add one or more reviewers
- [x] you followed our checklist for [functional testing](https://github.com/Amsterdam/vergunningcheck/blob/master/TESTING.md)
- [x] you added the necessary documentation (either in the markdown files or inline)
- [x] you added the necessary automated tests

Result is:
![image](https://user-images.githubusercontent.com/7781865/95887633-60722380-0d80-11eb-9f7e-d67c4f736ab6.png)

![image](https://user-images.githubusercontent.com/7781865/95887645-649e4100-0d80-11eb-8396-8cfb123e904e.png)
