### PR TITLE
Skip the intro page on the OLO flow

### DIFF
--- a/packages/client/src/components/Location/LocationInput.tsx
+++ b/packages/client/src/components/Location/LocationInput.tsx
@@ -148,7 +148,7 @@ const LocationInput: React.FC<{
           noMarginBottom={!hasIMTR}
           onGoToPrev={onGoToPrev}
           showNext
-          showPrev
+          showPrev={hasIMTR}
         />
       </Form>
     </>

--- a/packages/client/src/pages/IntroPage.tsx
+++ b/packages/client/src/pages/IntroPage.tsx
@@ -26,24 +26,25 @@ const IntroPage: React.FC<IntroPageProps> = ({
 
   const { hasIMTR, intro, text } = topic;
 
+  // Here starts the separation of the IMTR flow and the non-IMTR flow (which we call OLO flow):
+  if (!hasIMTR) {
+    // OLO flow now skips the intro page and goes directly to location page
+    history.replace(geturl(routes.oloLocationInput, topic));
+    return null;
+  }
+
   const introComponentPath = intro || "shared/DynamicIMTRIntro";
 
   const Intro = React.lazy(() => import(`../intros/${introComponentPath}`));
 
   const goToNext = () => {
-    // Here starts the separation of the IMTR flow and the non-IMTR flow (which we call OLO flow):
-    if (hasIMTR) {
-      // @TODO: Change and refactor this because the next step is not always LOCATION_INPUT
-      matomoTrackEvent({
-        action: actions.ACTIVE_STEP,
-        name: sections.LOCATION_INPUT,
-      });
+    // @TODO: Change and refactor this because the next step is not always LOCATION_INPUT
+    matomoTrackEvent({
+      action: actions.ACTIVE_STEP,
+      name: sections.LOCATION_INPUT,
+    });
 
-      history.push(geturl(routes.checker, topic));
-    } else {
-      // non-IMTR flow (OLO flow)
-      history.push(geturl(routes.oloLocationInput, topic));
-    }
+    history.push(geturl(routes.checker, topic));
   };
 
   return (

--- a/packages/e2e/nightwatch/tests/oloFlow.js
+++ b/packages/e2e/nightwatch/tests/oloFlow.js
@@ -30,18 +30,8 @@ module.exports = {
 
     b.url(`${domain}/aanbouw-of-uitbouw-maken`);
     assert.titleContains(
-      "Inleiding - Vergunningcheck aanbouw of uitbouw maken"
+      "Invullen adres - Vergunningcheck aanbouw of uitbouw maken"
     );
-
-    // forward, back, (back because of bug), forward
-    b.click(navButtonNext);
-    b.waitForElementVisible(navButtonPrev);
-    b.click(navButtonPrev);
-    assert.containsText(
-      main,
-      "U gebruikt deze informatie om de vergunningcheck te doen op het Omgevingsloket."
-    );
-    b.click(navButtonNext);
 
     assert.containsText(main, "Invullen adres");
     // TODO: test invalid fields feedback


### PR DESCRIPTION
As discussed with UX: we're skipping the Intro page on the OLO flow. Mainly because there is nothing useful to tell the user.

I've also updated the e2e test for the OLO flow.

I'm working on a unit test

Please make sure:
- [x] to add a label
- [x] to add one or more reviewers
- [x] you followed our checklist for [functional testing](https://github.com/Amsterdam/vergunningcheck/blob/master/TESTING.md)
- [x] you added the necessary documentation (either in the markdown files or inline)
- [ ] you added the necessary automated tests
