### PR TITLE
Disable autoFocus when `postalCode` has been found

### DIFF
--- a/packages/client/src/components/Location/LocationFinder.tsx
+++ b/packages/client/src/components/Location/LocationFinder.tsx
@@ -232,7 +232,7 @@ const LocationFinder: React.FC<{
     <>
       <ComponentWrapper>
         <LocationTextField
-          autoFocus
+          autoFocus={!postalCode}
           defaultValue={postalCode}
           error={
             !!postalCodeError ||


### PR DESCRIPTION
This PR fixes a bug with autoFocus on pages where postalCode can be found.

Please make sure:
- [x] to add a label
- [x] to add one or more reviewers
- [x] you followed our checklist for [functional testing](https://github.com/Amsterdam/vergunningcheck/blob/master/TESTING.md)
