### PR TITLE
fixed new checker initial bug

### DIFF
--- a/packages/client/src/components/Conclusion/NewCheckerModal.tsx
+++ b/packages/client/src/components/Conclusion/NewCheckerModal.tsx
@@ -36,7 +36,6 @@ const NewCheckerModal: React.FC<{
     const hasError = saveAddress === null;
 
     setError(hasError);
-    setFinished(!!checkerSlug);
 
     if (hasError) {
       matomoTrackEvent({
@@ -44,8 +43,8 @@ const NewCheckerModal: React.FC<{
         name: `${eventNames.DO_ANOTHER_CHECK} - ${eventNames.NO_CHOICE_HAS_BEEN_MADE}`,
       });
     } else {
+      setFinished(!!checkerSlug);
       const doSaveAddress = saveAddress === true;
-
       const saveAddressEvent = doSaveAddress
         ? eventNames.WITH_THE_SAME_ADDRESS
         : eventNames.WITHOUT_THE_SAME_ADDRESS;


### PR DESCRIPTION
Description 
This PR fixes a bug where the modal closes even if not making a decision on the form. 

Please make sure:
- [x] to add a label
- [x] to add one or more reviewers
- [x] you followed our checklist for [functional testing](https://github.com/Amsterdam/vergunningcheck/blob/master/TESTING.md)
- [x] you added the necessary documentation (either in the markdown files or inline)
- [x] you added the necessary automated tests
