### PR TITLE
export getChecker as named function instead of default export

### DIFF
--- a/packages/client/src/hoc/withChecker.tsx
+++ b/packages/client/src/hoc/withChecker.tsx
@@ -1,4 +1,4 @@
-import getChecker from "@vergunningcheck/imtr-client";
+import { getChecker } from "@vergunningcheck/imtr-client";
 import React, { useContext, useEffect, useState } from "react";
 import { useLocation, useParams } from "react-router-dom";
 

--- a/packages/imtr-client/index.ts
+++ b/packages/imtr-client/index.ts
@@ -1,4 +1,4 @@
-export { default } from "./src";
+export { getChecker } from "./src";
 
 export type { Input, Answer } from "./src/types";
 export type {

--- a/packages/imtr-client/src/index.js
+++ b/packages/imtr-client/src/index.js
@@ -83,7 +83,7 @@ function getDecision(id, decisionConfig, questions) {
  * @param {any} config - the config coming from json
  * @returns {Checker} the new Checker object
  */
-export default (config) => {
+export const getChecker = (config) => {
   const { permits: permitsConfig } = config;
   if (!permitsConfig || permitsConfig.length === 0) {
     throw new Error("Permits cannot be empty.");

--- a/packages/imtr-client/src/index.test.js
+++ b/packages/imtr-client/src/index.test.js
@@ -1,4 +1,4 @@
-import getChecker from "./index";
+import { getChecker } from "./index";
 
 describe("imtr client", () => {
   test("getChecker", () => {


### PR DESCRIPTION
Based on request by @robinpiets 