### PR TITLE
Added intro text translations to tests

### DIFF
--- a/packages/client/src/intros/DakkapelIntro.test.tsx
+++ b/packages/client/src/intros/DakkapelIntro.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 
+import text from "../i18n/nl";
 import { render, screen } from "../utils/test-utils";
 import DakkapelIntro from "./DakkapelIntro";
 
@@ -11,6 +12,9 @@ it("DakkapelIntro renders correctly", () => {
   render(<DakkapelIntro />);
 
   expect(
-    screen.queryByText("een nieuwe dakkapel", { exact: false })
+    screen.queryByText(
+      text.translation.introPage.dakkapel["intro description"],
+      { exact: false }
+    )
   ).toBeInTheDocument();
 });

--- a/packages/client/src/intros/DakraamIntro.test.tsx
+++ b/packages/client/src/intros/DakraamIntro.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 
+import text from "../i18n/nl";
 import { render, screen } from "../utils/test-utils";
 import DakraamIntro from "./DakraamIntro";
 
@@ -12,7 +13,7 @@ it("DakraamIntro renders correctly", () => {
 
   expect(
     screen.queryByText(
-      "Deze vergunningcheck gaat over dakramen, daklichten en lichtstraten.",
+      text.translation.introPage.dakraam["intro description"],
       { exact: false }
     )
   ).toBeInTheDocument();

--- a/packages/client/src/intros/KozijnenIntro.test.tsx
+++ b/packages/client/src/intros/KozijnenIntro.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 
+import text from "../i18n/nl";
 import { render, screen } from "../utils/test-utils";
 import KozijnenIntro from "./KozijnenIntro";
 
@@ -12,7 +13,7 @@ it("KozijnenIntro renders correctly", () => {
 
   expect(
     screen.queryByText(
-      "Deze vergunningcheck gaat over kozijnen, deuren, ramen en panelen.",
+      text.translation.introPage.kozijnen["intro description"],
       { exact: false }
     )
   ).toBeInTheDocument();

--- a/packages/client/src/intros/ZonnepanelenIntro.test.tsx
+++ b/packages/client/src/intros/ZonnepanelenIntro.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 
+import text from "../i18n/nl";
 import { render, screen } from "../utils/test-utils";
 import ZonnepanelenIntro from "./ZonnepanelenIntro";
 
@@ -11,8 +12,11 @@ it("ZonnepanelenIntro renders correctly", () => {
   render(<ZonnepanelenIntro />);
 
   expect(
-    screen.queryByText("nieuwe zonnepanelen of een nieuwe zonneboiler", {
-      exact: false,
-    })
+    screen.queryByText(
+      text.translation.introPage.zonnepanelen["intro description"],
+      {
+        exact: false,
+      }
+    )
   ).toBeInTheDocument();
 });

--- a/packages/client/src/intros/ZonweringRolluikIntro.test.tsx
+++ b/packages/client/src/intros/ZonweringRolluikIntro.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 
+import text from "../i18n/nl";
 import { render, screen } from "../utils/test-utils";
 import ZonweringRolluikIntro from "./ZonweringRolluikIntro";
 
@@ -11,6 +12,9 @@ it("ZonweringRolluikIntro renders correctly", () => {
   render(<ZonweringRolluikIntro />);
 
   expect(
-    screen.queryByText("zonwering, rolhek, rolluik of luik", { exact: false })
+    screen.queryByText(
+      text.translation.introPage.zonwering["intro description"],
+      { exact: false }
+    )
   ).toBeInTheDocument();
 });


### PR DESCRIPTION
Description 
We added i18n to the intro pages already. 
But the translations where still missing in the tests. 

This pr adds the missing translation keys in the test of the intro pages. 

Please make sure:
- [x] to add a label
- [x] to add one or more reviewers
- [x] you followed our checklist for [functional testing](https://github.com/Amsterdam/vergunningcheck/blob/master/TESTING.md)
- [x] you added the necessary documentation (either in the markdown files or inline)
- [x] you added the necessary automated tests
