### PR TITLE
Hooks > Fixes some bugs with resetting checker

### DIFF
--- a/packages/client/src/CheckerContext.tsx
+++ b/packages/client/src/CheckerContext.tsx
@@ -3,20 +3,14 @@ import React from "react";
 import { createContext, useState } from "react";
 
 export type setCheckerFn = (checker: any) => void;
-export type setAutofillDataFn = (autofillData: any) => void;
 
 type CheckerContextType = {
   checker?: Checker;
-  autofillData: any;
-
   setChecker: setCheckerFn;
-  setAutofillData: setAutofillDataFn;
 };
 
 const defaultCheckerContext: CheckerContextType = {
-  autofillData: {},
   setChecker: () => {},
-  setAutofillData: () => {},
 };
 
 export const CheckerContext = createContext<CheckerContextType>(
@@ -25,24 +19,19 @@ export const CheckerContext = createContext<CheckerContextType>(
 
 type CheckerProviderProps = {
   defaultChecker?: Checker;
-  defaultAutofillData?: any;
 };
 
 export const CheckerProvider: React.FC<CheckerProviderProps> = ({
   children,
   defaultChecker = undefined,
-  defaultAutofillData = {},
 }) => {
   const [checker, setChecker] = useState(defaultChecker);
-  const [autofillData, setAutofillData] = useState(defaultAutofillData);
 
   return (
     <CheckerContext.Provider
       value={{
         checker,
         setChecker,
-        autofillData,
-        setAutofillData,
       }}
     >
       {children}

--- a/packages/client/src/SessionContext.tsx
+++ b/packages/client/src/SessionContext.tsx
@@ -2,7 +2,7 @@ import { Answer } from "@vergunningcheck/imtr-client";
 import React, { useEffect, useReducer } from "react";
 import { createContext } from "react";
 
-// import { useSlug } from "./hooks";
+import { sections } from "./config/matomo";
 import { getSlugFromPathname } from "./utils";
 
 export type TopicData = {
@@ -16,7 +16,7 @@ export type TopicData = {
 };
 
 export const defaultTopicSession: TopicData = {
-  activeComponents: ["locatie invoer"],
+  activeComponents: [sections.LOCATION_INPUT],
   answers: {},
   address: null,
   finishedComponents: [],

--- a/packages/client/src/components/Conclusion/NewCheckerModal.tsx
+++ b/packages/client/src/components/Conclusion/NewCheckerModal.tsx
@@ -68,14 +68,11 @@ const NewCheckerModal: React.FC = () => {
         activeComponents: [activeComponents],
         address: saveAddress ? topicData.address : null,
         answers: {},
-        finishedComponents: saveAddress ? [sections.LOCATION_RESULT] : [],
+        finishedComponents: saveAddress ? [sections.LOCATION_INPUT] : [],
         questionIndex: 0,
       });
 
       checkerContext.setChecker(undefined);
-      checkerContext.setAutofillData(
-        saveAddress ? { address: topicData.address } : null
-      );
       history.push(geturl(routes.checker, { slug: checkerSlug }));
     }
   };

--- a/packages/client/src/components/Location/LocationInput.tsx
+++ b/packages/client/src/components/Location/LocationInput.tsx
@@ -1,11 +1,10 @@
 import { Heading, Paragraph } from "@amsterdam/asc-ui";
 import { ApolloError } from "@apollo/client";
-import React, { useContext, useState } from "react";
+import React, { useState } from "react";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";
 
-import { CheckerContext } from "../../CheckerContext";
 import { actions, eventNames, sections } from "../../config/matomo";
 import { useTopic, useTopicData, useTracking } from "../../hooks";
 import { geturl, routes } from "../../routes";
@@ -27,7 +26,6 @@ const LocationInput = ({
 }: LocationInputProps) => {
   const topic = useTopic();
   const history = useHistory();
-  const { setAutofillData } = useContext(CheckerContext);
   const { matomoTrackEvent } = useTracking();
   const { handleSubmit } = useForm();
   const { topicData, setTopicData } = useTopicData();
@@ -72,7 +70,6 @@ const LocationInput = ({
         name: cityScape || eventNames.NO_CITYSCAPE,
       });
 
-      setAutofillData({ address });
       handleNewAddressSubmit(address);
     }
   };

--- a/packages/client/src/components/Location/LocationSummary.test.tsx
+++ b/packages/client/src/components/Location/LocationSummary.test.tsx
@@ -11,13 +11,11 @@ import LocationSummary from "./LocationSummary";
 describe("LocationSummary", () => {
   const WrapperWithContext = (
     props: React.ComponentProps<typeof LocationSummary>
-  ) => {
-    return (
-      <CheckerProvider defaultAutofillData={{ address: addressMock }}>
-        <LocationSummary {...props} />
-      </CheckerProvider>
-    );
-  };
+  ) => (
+    <CheckerProvider>
+      <LocationSummary {...props} />
+    </CheckerProvider>
+  );
 
   describe("renders in STTR Flow", () => {
     it("on LocationFinder (with all restrictions)", () => {

--- a/packages/client/src/hooks/useChecker.ts
+++ b/packages/client/src/hooks/useChecker.ts
@@ -15,13 +15,21 @@ export default () => {
   const topic = useTopic();
 
   useEffect(() => {
-    initChecker();
+    // Initilize the checker on first load, reload and on reset
+    if (!checker && !checkerContext.checker) {
+      initChecker();
+    }
+    // Force clearing the checker when the checker has been reset on the context
+    if (checker && !checkerContext.checker) {
+      setChecker(undefined);
+    }
     //eslint-disable-next-line
-  }, []);
+  }, [checker, checkerContext]);
 
   const initChecker = async () => {
     // if the topic is not found (dynamic IMTR-checker) or the topic is found and has an imtr flow
-    if (!checker && !error && (!topic || topic.hasIMTR)) {
+    const loadChecker = !checker && !error && (!topic || topic.hasIMTR);
+    if (loadChecker) {
       try {
         const topicConfig = topicsJson
           .flat()
@@ -54,7 +62,6 @@ export default () => {
         }
 
         // Store the entire `imtr-checker` in React Context
-        checkerContext.setAutofillData({ address });
         checkerContext.setChecker(newChecker);
         setChecker(newChecker);
       } catch (e) {
@@ -68,8 +75,6 @@ export default () => {
     checker,
     setChecker: (checker: Checker | undefined) => {
       checkerContext.setChecker(checker);
-      checkerContext.setAutofillData({});
-      setChecker(checker);
     },
   };
 };


### PR DESCRIPTION
This PR:
- fixes this bug: "Questions component seem to still shows the questions even when `checker = undefined;`" [Trello card](https://trello.com/c/d4xC87mL/1708-react-hooks-afmaken)
- fixes a bug with showing the correct `finishedComponent` when using the `NewCheckerModal`
- removes the unused `autofillData` and `setAutofillData`. Do you still need that, @afjlambert ?
- has some refactors

I didn't namespace the CheckerContext by slug, because that was far more work than this fix. I don't know if you still want to do that? Seems a bit out of scope IMHO, but let's discuss.

I also didn't add any unit tests, I can do that later

Please make sure:
- [x] to add a label
- [x] to add one or more reviewers
- [x] you followed our checklist for [functional testing](https://github.com/Amsterdam/vergunningcheck/blob/master/TESTING.md)
- [x] you added the necessary documentation (either in the markdown files or inline)
- [ ] you added the necessary automated tests
