### PR TITLE
Fixed bug with Need-Report outcome for single checker

### DIFF
--- a/packages/client/src/components/Conclusion/Conclusion.tsx
+++ b/packages/client/src/components/Conclusion/Conclusion.tsx
@@ -74,6 +74,12 @@ const Conclusion: React.FC<ConclusionProps & MatomoTrackEventProps> = ({
         mainContent: <NeedPermit />,
         title: t("outcome.needPermit.you need a permit"),
       },
+      [NEED_REPORT]: {
+        mainContent: (
+          <NeedPermit contentText="Demo text for need permit outcome. We don't fully support this outcome yet" />
+        ),
+        title: t("outcome.needReport.you need a report"),
+      },
       [PERMIT_FREE]: {
         footerContent: <PermitFree />,
         title: t("outcome.permitFree.you dont need a permit"),


### PR DESCRIPTION
This bug fixes [this issue](https://trello.com/c/2qlij8zs/196-soms-krijg-je-een-witte-uitkomsten-pagina)

---

Result (instead of white screen of death):
![image](https://user-images.githubusercontent.com/7781865/99978384-2bf17e80-2da6-11eb-9c7b-cfed9265d5cc.png)

Please make sure:
- [x] to add a label
- [x] to add one or more reviewers
- [x] you followed our checklist for [functional testing](https://github.com/Amsterdam/vergunningcheck/blob/master/TESTING.md)