### PR TITLE
ClientOutcomes is more robust because it's converted to enum

### DIFF
--- a/packages/client/src/components/Conclusion/Conclusion.tsx
+++ b/packages/client/src/components/Conclusion/Conclusion.tsx
@@ -1,7 +1,7 @@
 import { themeSpacing } from "@amsterdam/asc-ui";
 import {
   Checker,
-  clientOutcomes,
+  ClientOutcomes,
   imtrOutcomes,
 } from "@vergunningcheck/imtr-client";
 import React from "react";
@@ -33,7 +33,7 @@ const {
   NEED_PERMIT,
   NEED_REPORT,
   PERMIT_FREE,
-} = clientOutcomes;
+} = ClientOutcomes;
 
 type ConclusionProps = {
   checker: Checker;
@@ -61,6 +61,11 @@ const Conclusion: React.FC<ConclusionProps & MatomoTrackEventProps> = ({
   const contents = {
     // This is the default content
     default: {
+      [NEED_BOTH_PERMIT_AND_REPORT]: {
+        title: t(
+          "outcome.needBothPermitAndReport.you need both permit and report"
+        ),
+      },
       [NEED_CONTACT]: {
         mainContent: (
           <Markdown
@@ -68,7 +73,10 @@ const Conclusion: React.FC<ConclusionProps & MatomoTrackEventProps> = ({
             source={getNeedContactContent?.description || ""}
           />
         ),
-        title: getNeedContactContent?.title || "",
+        title:
+          getNeedContactContent?.title ||
+          t("outcome.needContact.Neem contact op met de gemeente") || // Fallback text
+          "",
       },
       [NEED_PERMIT]: {
         mainContent: <NeedPermit />,
@@ -87,6 +95,12 @@ const Conclusion: React.FC<ConclusionProps & MatomoTrackEventProps> = ({
     },
     // This content is only relevant for the demolition checker
     demolition: {
+      [NEED_CONTACT]: {
+        title:
+          getNeedContactContent?.title ||
+          t("outcome.needContact.Neem contact op met de gemeente") || // Fallback text
+          "",
+      },
       [NEED_BOTH_PERMIT_AND_REPORT]: {
         mainContent: (
           <NeedPermit
@@ -132,6 +146,7 @@ const Conclusion: React.FC<ConclusionProps & MatomoTrackEventProps> = ({
   // This part can be refactored whenever we have another checker that have custom outcomes
   const checkerContent =
     topic.name === "Bouwwerk slopen" ? contents.demolition : contents.default;
+
   const conclusionContent = checkerContent[outcomeType];
   const showDiscaimer = outcomeType !== NEED_CONTACT;
 

--- a/packages/client/src/components/Conclusion/ConclusionOutcome.tsx
+++ b/packages/client/src/components/Conclusion/ConclusionOutcome.tsx
@@ -1,5 +1,5 @@
 import { Heading, themeSpacing } from "@amsterdam/asc-ui";
-import { imtrOutcomes } from "@vergunningcheck/imtr-client";
+import { ClientOutcomes } from "@vergunningcheck/imtr-client";
 import React, { ReactNode, useEffect } from "react";
 import { isIE, isMobile } from "react-device-detect";
 import styled, { css } from "styled-components";
@@ -31,7 +31,7 @@ type ConclusionContentProps = {
 type ConclusionOutcomeProps = {
   conclusionContent: ConclusionContentProps;
   matomoTrackEvent: Function;
-  outcomeType: string; // @TODO: maybe define imtrOutcomes types and import from imtr-client?
+  outcomeType: ClientOutcomes;
   showDiscaimer?: boolean;
 };
 
@@ -69,7 +69,7 @@ const ConclusionOutcome: React.FC<
         {!isIE && !isMobile && (
           <PrintButton
             data-testid={PRINT_BUTTON}
-            marginBottom={outcomeType === imtrOutcomes.PERMIT_FREE ? 32 : 40}
+            marginBottom={outcomeType === ClientOutcomes.PERMIT_FREE ? 32 : 40}
             onClick={handlePrintButton}
             variant="textButton"
           >

--- a/packages/client/src/components/Conclusion/content/PermitFree.tsx
+++ b/packages/client/src/components/Conclusion/content/PermitFree.tsx
@@ -19,7 +19,7 @@ const PermitFree: React.FC = () => {
         <ListItem>{t("outcome.payAttentionTo.take in account")}</ListItem>
       </List>
       <Heading forwardedAs={"h3"}>
-        {"outcome.thinkAbout.also think about"}
+        {t("outcome.thinkAbout.also think about")}
       </Heading>
       <List variant={"bullet"}>
         <ListItem>{t("outcome.thinkAbout.placement of a crane")}</ListItem>

--- a/packages/client/src/components/Question.tsx
+++ b/packages/client/src/components/Question.tsx
@@ -1,4 +1,7 @@
-import { Question as ImtrQuestion } from "@vergunningcheck/imtr-client";
+import {
+  ClientOutcomes,
+  Question as ImtrQuestion,
+} from "@vergunningcheck/imtr-client";
 import React, { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
@@ -33,7 +36,7 @@ type QuestionProps = {
   onGoToNext: () => void;
   onGoToPrev: () => void;
   questionIndex: number;
-  outcomeType: string;
+  outcomeType: ClientOutcomes;
   saveAnswer: (value: string) => void;
   shouldGoToConlusion: () => boolean;
   showQuestionAlert: boolean;

--- a/packages/client/src/components/QuestionAlert.test.tsx
+++ b/packages/client/src/components/QuestionAlert.test.tsx
@@ -1,7 +1,7 @@
 import "jest-styled-components";
 
 import { ascDefaultTheme, themeSpacing } from "@amsterdam/asc-ui";
-import { clientOutcomes } from "@vergunningcheck/imtr-client";
+import { ClientOutcomes } from "@vergunningcheck/imtr-client";
 import React from "react";
 
 import text from "../i18n/nl";
@@ -18,7 +18,7 @@ const needContactText =
 
 describe("QuestionAlert", () => {
   it("renders NEED_PERMIT variant correctly", () => {
-    render(<QuestionAlert outcomeType={clientOutcomes.NEED_PERMIT} />);
+    render(<QuestionAlert outcomeType={ClientOutcomes.NEED_PERMIT} />);
 
     const variant1 = screen.queryByText(needPermitText, { exact: false });
     expect(variant1).toBeInTheDocument();
@@ -36,7 +36,7 @@ describe("QuestionAlert", () => {
     render(
       <QuestionAlert
         marginBottom={1}
-        outcomeType={clientOutcomes.NEED_CONTACT}
+        outcomeType={ClientOutcomes.NEED_CONTACT}
       />
     );
 

--- a/packages/client/src/components/QuestionAlert.tsx
+++ b/packages/client/src/components/QuestionAlert.tsx
@@ -1,5 +1,5 @@
 import { Paragraph } from "@amsterdam/asc-ui";
-import { clientOutcomes } from "@vergunningcheck/imtr-client";
+import { ClientOutcomes } from "@vergunningcheck/imtr-client";
 import React from "react";
 import { useTranslation } from "react-i18next";
 
@@ -9,10 +9,10 @@ import { QuestionAlertStyle } from "./QuestionAlertStyles";
 
 export type QuestionAlertProps = {
   marginBottom?: number;
-  outcomeType: string;
+  outcomeType: ClientOutcomes;
 };
 
-const { NEED_CONTACT, NEED_PERMIT } = clientOutcomes;
+const { NEED_CONTACT, NEED_PERMIT } = ClientOutcomes;
 
 const QuestionAlert: React.FC<QuestionAlertProps> = ({
   marginBottom,

--- a/packages/client/src/components/QuestionAnswer.test.js
+++ b/packages/client/src/components/QuestionAnswer.test.js
@@ -1,4 +1,4 @@
-import { clientOutcomes } from "@vergunningcheck/imtr-client";
+import { ClientOutcomes } from "@vergunningcheck/imtr-client";
 import React from "react";
 
 import { render } from "../utils/test-utils";
@@ -7,7 +7,7 @@ import QuestionAnswer from "./QuestionAnswer";
 it("QuestionAnswer renders correctly", () => {
   const { queryByText } = render(
     <QuestionAnswer
-      outcomeType={clientOutcomes.NEED_PERMIT}
+      outcomeType={ClientOutcomes.NEED_PERMIT}
       showQuestionAlert
       userAnswer="yes sir"
     />

--- a/packages/client/src/components/QuestionAnswer.tsx
+++ b/packages/client/src/components/QuestionAnswer.tsx
@@ -1,5 +1,5 @@
 import { Paragraph } from "@amsterdam/asc-ui";
-import { removeQuotes } from "@vergunningcheck/imtr-client";
+import { ClientOutcomes, removeQuotes } from "@vergunningcheck/imtr-client";
 import React from "react";
 
 import { EditButton, TextToEdit } from "../atoms";
@@ -7,7 +7,7 @@ import QuestionAlert from "./QuestionAlert";
 
 type QuestionAnswerProps = {
   disabled?: boolean;
-  outcomeType: string;
+  outcomeType: ClientOutcomes;
   questionNeedsContactExit?: boolean;
   showQuestionAlert: boolean;
   userAnswer?: string;

--- a/packages/client/src/components/Questions.tsx
+++ b/packages/client/src/components/Questions.tsx
@@ -1,10 +1,10 @@
 import { setTag } from "@sentry/browser";
 import {
   Checker,
+  ClientOutcomes,
   Decision,
   Question as ImtrQuestion,
   Permit,
-  clientOutcomes,
   imtrOutcomes,
   removeQuotes,
 } from "@vergunningcheck/imtr-client";
@@ -214,18 +214,19 @@ const Questions: React.FC<
 
   // Check which questions are causing the need for a permit
   // @TODO: Move this to `imtr-client`
-  const permitsPerQuestion = [] as string[];
+  const permitsPerQuestion = [] as ClientOutcomes[];
   checker.permits.forEach((permit: Permit) => {
     const conclusionDecision = permit.getDecisionById("dummy");
 
     if (conclusionDecision) {
-      let outcomeType = "";
+      let outcomeType = ClientOutcomes.PERMIT_FREE;
+
       if (conclusionDecision.getOutput() === imtrOutcomes.NEED_CONTACT) {
-        outcomeType = clientOutcomes.NEED_CONTACT;
+        outcomeType = ClientOutcomes.NEED_CONTACT;
       } else if (conclusionDecision?.getOutput() === imtrOutcomes.NEED_PERMIT) {
-        outcomeType = clientOutcomes.NEED_PERMIT;
+        outcomeType = ClientOutcomes.NEED_PERMIT;
       } else if (conclusionDecision?.getOutput() === imtrOutcomes.NEED_REPORT) {
-        outcomeType = clientOutcomes.NEED_REPORT;
+        outcomeType = ClientOutcomes.NEED_REPORT;
       }
 
       if (outcomeType) {
@@ -343,7 +344,7 @@ const Questions: React.FC<
         const showQuestionAlert = !!permitsPerQuestion[i];
 
         // Define the outcome type
-        const outcomeType = permitsPerQuestion[i];
+        const outcomeType = permitsPerQuestion[i] as ClientOutcomes;
 
         return (
           <StepByStepItem
@@ -403,7 +404,7 @@ const Questions: React.FC<
         const disabled = checker.isConclusive() || disableFutureQuestions;
 
         // Define the outcome type
-        const outcomeType = permitsPerQuestion[i];
+        const outcomeType = permitsPerQuestion[i] as ClientOutcomes;
 
         return (
           <StepByStepItem

--- a/packages/client/src/components/Questions.tsx
+++ b/packages/client/src/components/Questions.tsx
@@ -345,7 +345,7 @@ const Questions: React.FC<
         const showQuestionAlert = !!permitsPerQuestion[i];
 
         // Define the outcome type
-        const outcomeType = permitsPerQuestion[i] as ClientOutcomes;
+        const outcomeType: ClientOutcomes = permitsPerQuestion[i];
 
         return (
           <StepByStepItem
@@ -405,7 +405,7 @@ const Questions: React.FC<
         const disabled = checker.isConclusive() || disableFutureQuestions;
 
         // Define the outcome type
-        const outcomeType = permitsPerQuestion[i] as ClientOutcomes;
+        const outcomeType: ClientOutcomes = permitsPerQuestion[i];
 
         return (
           <StepByStepItem

--- a/packages/client/src/i18n/nl.ts
+++ b/packages/client/src/i18n/nl.ts
@@ -120,12 +120,15 @@ export default {
       },
       needBothPermitAndReport: {
         "you need both permit and report":
-          "U hebt een omgevingsvergunning nodig.",
+          "U hebt een omgevingsvergunning nodig. U moet de activiteit ook melden.", // This text should only be used for unconfigured (non-amsterdam) checkers
         "you need both permit and report for demolition":
           "U hebt een omgevingsvergunning nodig. U moet de sloop ook melden.",
         "on this page you can read more how to do apply for demolition":
           "Op de pagina 'Sloop: melding en vergunning' leest u hoe u dit doet, hoe lang het duurt en wat het kost.",
         "demolition permit and report": "Sloop: melding en vergunning",
+      },
+      needContact: {
+        "you need to contact the city": "Neem contact op met de gemeente", // This text should only be used for unconfigured (non-amsterdam) checkers
       },
       needPermit: {
         "you need a permit": "U hebt een omgevingsvergunning nodig.",

--- a/packages/imtr-client/index.ts
+++ b/packages/imtr-client/index.ts
@@ -10,7 +10,7 @@ export type {
 
 export {
   default as Checker,
-  clientOutcomes,
+  ClientOutcomes,
   imtrOutcomes,
 } from "./src/models/checker";
 export { default as Decision } from "./src/models/decision";

--- a/packages/imtr-client/src/models/checker.ts
+++ b/packages/imtr-client/src/models/checker.ts
@@ -12,13 +12,13 @@ export const imtrOutcomes = {
   PERMIT_FREE: '"Toestemmingsvrij"',
 };
 
-export const clientOutcomes = {
-  NEED_BOTH_PERMIT_AND_REPORT: "NEED_BOTH_PERMIT_AND_REPORT",
-  NEED_CONTACT: "NEED_CONTACT",
-  NEED_PERMIT: "NEED_PERMIT",
-  NEED_REPORT: "NEED_REPORT",
-  PERMIT_FREE: "PERMIT_FREE",
-};
+export enum ClientOutcomes {
+  NEED_BOTH_PERMIT_AND_REPORT,
+  NEED_CONTACT,
+  NEED_PERMIT,
+  NEED_REPORT,
+  PERMIT_FREE,
+}
 
 export type AutofillData = {
   address?: any; // eslint-disable-line
@@ -368,10 +368,10 @@ export default class Checker {
 
   /**
    *
-   * Returns the final outcome for the client (as defined in `clientOutcomes`)
+   * Returns the final outcome for the client (as defined in `ClientOutcomes`)
    *
    */
-  getClientOutcomeType(): string {
+  getClientOutcomeType(): ClientOutcomes {
     const outcomes = this.getAllOutcomeTypes();
 
     const needContactOutcome = outcomes.find(
@@ -386,16 +386,16 @@ export default class Checker {
 
     if (needContactOutcome) {
       // The contact outcome has most priority to display
-      return clientOutcomes.NEED_CONTACT;
+      return ClientOutcomes.NEED_CONTACT;
     } else if (needPermitOutcome && needReportOutcome) {
-      return clientOutcomes.NEED_BOTH_PERMIT_AND_REPORT;
+      return ClientOutcomes.NEED_BOTH_PERMIT_AND_REPORT;
     } else if (needPermitOutcome) {
-      return clientOutcomes.NEED_PERMIT;
+      return ClientOutcomes.NEED_PERMIT;
     } else if (needReportOutcome) {
-      return clientOutcomes.NEED_REPORT;
+      return ClientOutcomes.NEED_REPORT;
     } else {
       // The fallback outcome is permit-free, this is inherited from Flo Legal and IMTR
-      return clientOutcomes.PERMIT_FREE;
+      return ClientOutcomes.PERMIT_FREE;
     }
   }
 }

--- a/packages/imtr-client/src/models/permit.test.ts
+++ b/packages/imtr-client/src/models/permit.test.ts
@@ -1,4 +1,4 @@
-import Checker, { clientOutcomes, imtrOutcomes } from "./checker";
+import Checker, { ClientOutcomes, imtrOutcomes } from "./checker";
 import Decision from "./decision";
 import Permit from "./permit";
 import Question from "./question";
@@ -70,7 +70,7 @@ describe("Permit", () => {
       imtrOutcomes.NEED_PERMIT
     );
     expect(checker.getAllOutcomeTypes()).toEqual([imtrOutcomes.NEED_PERMIT]);
-    expect(checker.getClientOutcomeType()).toBe(clientOutcomes.NEED_PERMIT);
+    expect(checker.getClientOutcomeType()).toBe(ClientOutcomes.NEED_PERMIT);
 
     question.setAnswer(false);
     expect(checker.permits[0].getOutputByDecisionId("dummy")).toBe(
@@ -87,6 +87,6 @@ describe("Permit", () => {
       imtrOutcomes.NEED_CONTACT
     );
     expect(checker.getAllOutcomeTypes()).toEqual([imtrOutcomes.NEED_CONTACT]);
-    expect(checker.getClientOutcomeType()).toBe(clientOutcomes.NEED_CONTACT);
+    expect(checker.getClientOutcomeType()).toBe(ClientOutcomes.NEED_CONTACT);
   });
 });

--- a/packages/imtr-client/src/types.ts
+++ b/packages/imtr-client/src/types.ts
@@ -9,10 +9,3 @@ export type Outcome = {
   title: string;
   description?: string;
 };
-// @TODO: make the client work with this predefined type
-export type ClientOutcome =
-  | "NEED_BOTH_PERMIT_AND_REPORT"
-  | "NEED_CONTACT"
-  | "NEED_PERMIT"
-  | "NEED_REPORT"
-  | "PERMIT_FREE";


### PR DESCRIPTION
This PR made `ClientOutcomes` way more robust by converting it to enum. Also, I've fixed the bug with the missing outcome text.

Please squash when approved.

Please make sure:
- [x] to add a label
- [x] to add one or more reviewers
- [x] you followed our checklist for [functional testing](https://github.com/Amsterdam/vergunningcheck/blob/master/TESTING.md)
- [x] you added the necessary documentation (either in the markdown files or inline)
- [x] you added the necessary automated tests
