### PR TITLE
Fixed bug with multiple pageviews

### DIFF
--- a/packages/client/src/components/Layouts/BaseLayout.tsx
+++ b/packages/client/src/components/Layouts/BaseLayout.tsx
@@ -9,12 +9,21 @@ import Footer from "../Footer";
 import Header from "../Header";
 import { Container, Content, ContentContainer } from "./BaseLayoutStyles";
 
-const BaseLayout: React.FC = ({ children }) => {
+type BaseLayoutProps = {
+  disablePageView?: boolean;
+};
+
+const BaseLayout: React.FC<BaseLayoutProps> = ({
+  children,
+  disablePageView,
+}) => {
   const { matomoPageView } = useTracking();
   const { location } = useHistory();
 
   useEffect(() => {
-    matomoPageView();
+    if (!disablePageView) {
+      matomoPageView();
+    }
     // @TODO: We need to fix this!
     //eslint-disable-next-line
   }, [location.pathname]);

--- a/packages/client/src/components/Router.tsx
+++ b/packages/client/src/components/Router.tsx
@@ -20,7 +20,7 @@ const Router = () => {
               <Route key={i} {...route} />
             ))}
         </Switch>
-      </Suspense>{" "}
+      </Suspense>
     </BrowserRouter>
   );
 };

--- a/packages/client/src/pages/LoadingPage.tsx
+++ b/packages/client/src/pages/LoadingPage.tsx
@@ -5,7 +5,7 @@ import { BaseLayout } from "../components/Layouts";
 import Loading from "../components/Loading";
 
 const LoadingPage: React.FC = () => (
-  <BaseLayout>
+  <BaseLayout disablePageView>
     <Helmet>
       <title>Laden... - Amsterdam Vergunningcheck</title>
     </Helmet>


### PR DESCRIPTION
This PR fixes the annoying bug with multiple pageview events on reload. The problem was that the LoadingPage was also recording pageviews. This should not happen, because it's not really a 'page'. It just uses the Topic Layout to look nice.