### PR TITLE
Fixed bugs with going to new checkers

### DIFF
--- a/packages/client/src/CheckerContext.tsx
+++ b/packages/client/src/CheckerContext.tsx
@@ -1,6 +1,8 @@
 import { Checker } from "@vergunningcheck/imtr-client";
-import React from "react";
+import React, { useEffect } from "react";
 import { createContext, useState } from "react";
+
+import { useSlug } from "./hooks";
 
 export type setCheckerFn = (checker?: Checker) => void;
 
@@ -26,6 +28,12 @@ export const CheckerProvider: React.FC<CheckerProviderProps> = ({
   defaultChecker = undefined,
 }) => {
   const [checker, setChecker] = useState(defaultChecker);
+  const slug = useSlug();
+
+  useEffect(() => {
+    // The slug changed, so uncheck the current checker
+    setChecker(undefined);
+  }, [slug]);
 
   return (
     <CheckerContext.Provider

--- a/packages/client/src/SessionContext.tsx
+++ b/packages/client/src/SessionContext.tsx
@@ -134,17 +134,18 @@ export const SessionProvider: React.FC = ({ children }) => {
 
   useEffect(() => {
     // Prevent HomePage and other pages from not setting session data
-    if (!findTopicBySlug(slug) || !topicData.type) {
+    if (!findTopicBySlug(slug)) {
       return;
     }
 
-    // Update the `slug` key in `session` with the updated `topicData`
-    if (topicData.type !== slug) {
+    // Error when there's a mismatch between expected slug
+    if (topicData.type && topicData.type !== slug) {
       throw new Error(
         `topicData.type ('${topicData.type}') is not equal to slug ('${slug}')`
       );
     }
 
+    // Update the `slug` key in `session` with the updated `topicData`
     setSession({ [slug]: topicData });
 
     // eslint-disable-next-line

--- a/packages/client/src/SessionContext.tsx
+++ b/packages/client/src/SessionContext.tsx
@@ -118,15 +118,15 @@ export const SessionProvider: React.FC = ({ children }) => {
     }
 
     // Set the topic/session data when (re)initilizing
-    const initialState = slugSession || defaultTopicSession;
+    const newTopicData = slugSession || defaultTopicSession;
     if (!topicData || topicData.type !== slug) {
-      if (!initialState.type || initialState.type !== slug) {
+      if (!newTopicData.type || newTopicData.type !== slug) {
         // Set the topic `type` to the session, so we can compare the topicData
-        initialState.type = slug;
+        newTopicData.type = slug;
       }
 
-      setTopicData(initialState);
-      setSession({ [slug]: initialState });
+      setTopicData(newTopicData);
+      setSession({ [slug]: newTopicData });
     }
 
     // eslint-disable-next-line
@@ -134,12 +134,12 @@ export const SessionProvider: React.FC = ({ children }) => {
 
   useEffect(() => {
     // Prevent HomePage and other pages from not setting session data
-    if (!findTopicBySlug(slug)) {
+    if (!findTopicBySlug(slug) || !topicData.type) {
       return;
     }
 
     // Update the `slug` key in `session` with the updated `topicData`
-    if (topicData?.type !== slug) {
+    if (topicData.type !== slug) {
       throw new Error(
         `topicData.type ('${topicData.type}') is not equal to slug ('${slug}')`
       );

--- a/packages/client/src/SessionContext.tsx
+++ b/packages/client/src/SessionContext.tsx
@@ -54,7 +54,7 @@ export type setTopicFn = (topicData: null | Partial<TopicData>) => void;
 export type setSessionFn = (sessionData: Partial<SessionData>) => void;
 
 export type SessionData = {
-  [slug: string]: TopicData;
+  [slug: string]: null | TopicData;
 };
 
 export type setTopicSessionDataFn = (
@@ -114,13 +114,23 @@ export const SessionProvider: React.FC = ({ children }) => {
   useEffect(() => {
     // Update the `session` with default `topicData` when the `slug` changes
     if (slug && !session[slug]) {
+      // In this case the default data has to be set, because the `topic` has not been visited
       setSession({ [slug]: defaultTopicSession });
       setTopicData(defaultTopicSession);
+    } else if (slug && topicData.type !== session[slug]?.type) {
+      // In this case the `topic` has already been visited and the old topicData does not match the new required topic
+      // so the new topicData needs to be forced from the new `slug`
+      setTopicData(session[slug]);
     }
     // eslint-disable-next-line
   }, [slug]);
 
   useEffect(() => {
+    // Set the topic `type` to the session, so we can compare the topicData
+    if (!topicData.type) {
+      topicData.type = slug;
+    }
+
     // Update the `slug` key in `session` with the updated `topicData`
     setSession({ [slug]: topicData });
     // eslint-disable-next-line

--- a/packages/client/src/components/Conclusion/NewCheckerModal.tsx
+++ b/packages/client/src/components/Conclusion/NewCheckerModal.tsx
@@ -9,7 +9,7 @@ import { topics } from "../../config";
 import { actions, eventNames, sections } from "../../config/matomo";
 import { useSlug, useTopicData, useTracking } from "../../hooks";
 import { geturl, routes } from "../../routes";
-import { SessionContext } from "../../SessionContext";
+import { SessionContext, defaultTopicSession } from "../../SessionContext";
 import {
   NEW_CHECKER_MODAL_SAME_ADDRESS,
   RADIO_ADDRESS_1,
@@ -69,17 +69,18 @@ const NewCheckerModal: React.FC = () => {
       });
 
       // Set the the new session data for `doSaveAddress`
-      const topicDataForSaveAddress = {
+      const topicSessionWithSavedAddress = {
+        ...defaultTopicSession,
         activeComponents: [sections.QUESTIONS],
         address: topicData.address,
-        answers: {},
         finishedComponents: [sections.LOCATION_INPUT],
-        questionIndex: 0,
         type: checkerSlug,
       };
 
       // Set the new topic data. SessionContext will interpret `null` by replacing it with default data.
-      const newTopicData = doSaveAddress ? topicDataForSaveAddress : null;
+      const newTopicData = doSaveAddress
+        ? topicSessionWithSavedAddress
+        : defaultTopicSession;
 
       if (checkerSlug === slug) {
         // Only change the topicData for the current topic

--- a/packages/client/src/components/Header.tsx
+++ b/packages/client/src/components/Header.tsx
@@ -1,5 +1,4 @@
 import React, { memo } from "react";
-import { useHistory } from "react-router-dom";
 
 import { actions, eventNames, sections } from "../config/matomo";
 import { useTracking } from "../hooks";
@@ -13,29 +12,29 @@ import {
 
 export const Header = () => {
   const { matomoTrackEvent } = useTracking();
-  const history = useHistory();
 
   const handleClick = (e: React.MouseEvent<HTMLElement, MouseEvent>) => {
     matomoTrackEvent({
       action: actions.CLICK_EXTERNAL_NAVIGATION,
       name: `${eventNames.LOGO} - ${sections.HEADER}`,
     });
-    if (process.env.NODE_ENV !== "production") {
-      e.preventDefault();
-      history.push(routes.home);
-    }
   };
+
+  const homeLink =
+    process.env.NODE_ENV === "production"
+      ? "https://amsterdam.nl/"
+      : routes.home;
 
   return (
     <StyledHeader
-      homeLink="https://amsterdam.nl/"
-      tall
       css={StyledHeaderWrapper}
+      homeLink=""
       logo={() => (
-        <StyledLogoWrapper onClick={handleClick} tabIndex={4}>
+        <StyledLogoWrapper href={homeLink} onClick={handleClick} tabIndex={4}>
           <StyledLogo />
         </StyledLogoWrapper>
       )}
+      tall
     />
   );
 };

--- a/packages/client/src/components/Location/EditLocationModal.tsx
+++ b/packages/client/src/components/Location/EditLocationModal.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { ComponentWrapper, EditButton } from "../../atoms";
 import { actions, eventNames } from "../../config/matomo";
 import { useChecker, useTopicData, useTracking } from "../../hooks";
+import { defaultTopicSession } from "../../SessionContext";
 import { LOCATION_MODAL_OPEN_BUTTON } from "../../utils/test-ids";
 import Modal from "../Modal";
 
@@ -25,7 +26,7 @@ const EditLocationModal: React.FC = () => {
       name: `${eventNames.EDIT_ADDRESS} - ${eventNames.BACK} ${eventNames.GOTO_LOCATION}`,
     });
 
-    setTopicData(null);
+    setTopicData(defaultTopicSession);
     setChecker(undefined);
   };
 

--- a/packages/client/src/components/Location/LocationInput.tsx
+++ b/packages/client/src/components/Location/LocationInput.tsx
@@ -33,13 +33,13 @@ const LocationInput = ({
   const { t } = useTranslation();
 
   const { hasIMTR, slug, text } = topic;
-  const address: Address = topicData.address || null;
+  const { address } = topicData;
   const [errorMessage, setError] = useState<ApolloError | undefined>(error);
 
   const [focus, setFocus] = useState(false);
 
   const onSubmit = () => {
-    if (address && address.postalCode) {
+    if (address?.postalCode) {
       const monument = getRestrictionByTypeName(
         address.restrictions,
         "Monument"

--- a/packages/client/src/components/Location/LocationSummary.test.tsx
+++ b/packages/client/src/components/Location/LocationSummary.test.tsx
@@ -8,6 +8,14 @@ import { CheckerProvider } from "../../CheckerContext";
 import { render, screen } from "../../utils/test-utils";
 import LocationSummary from "./LocationSummary";
 
+// Somehow this testfile needs to reinitialize `pathname`
+jest.mock("react-router-dom", () => ({
+  ...(jest.requireActual("react-router-dom") as {}),
+  useLocation: () => ({
+    pathname: "/dakkapel-plaatsen",
+  }),
+}));
+
 describe("LocationSummary", () => {
   const WrapperWithContext = (
     props: React.ComponentProps<typeof LocationSummary>

--- a/packages/client/src/components/Location/LocationSummary.tsx
+++ b/packages/client/src/components/Location/LocationSummary.tsx
@@ -59,7 +59,7 @@ const LocationSummary: React.FC<LocationSummaryProps> = ({
 }) => {
   const topic = useTopic();
   const { topicData } = useTopicData();
-  const address = addressFromLocation ? addressFromLocation : topicData.address;
+  const address = addressFromLocation ?? topicData.address;
 
   const { restrictions } = address || {};
   const { hasIMTR } = topic;

--- a/packages/client/src/debug/DebugVariables.tsx
+++ b/packages/client/src/debug/DebugVariables.tsx
@@ -1,11 +1,4 @@
-import {
-  Accordion,
-  Card,
-  CardContent,
-  Heading,
-  Link,
-  Paragraph,
-} from "@amsterdam/asc-ui";
+import { Accordion, Card, CardContent, Heading, Link } from "@amsterdam/asc-ui";
 import React, { useContext } from "react";
 
 import Permit from "../../../imtr-client/src/models/permit";
@@ -37,88 +30,127 @@ const DebugVariables: React.FC<DebugVariablesProps> = () => {
       <Accordion title="Debug informatie">
         <Card backgroundColor="level2" shadow>
           <CardContent>
-            <Heading forwardedAs="h2">Checker context</Heading>
+            <Heading forwardedAs="h2">Summary</Heading>
+            <p>
+              current slug (slug): <strong>{slug}</strong>
+            </p>
+
+            <p>
+              current topic (topicData): <strong>{topicData?.type}</strong>
+            </p>
+
+            <p>
+              current topic (topic): <strong>{topic?.slug}</strong>
+            </p>
+
+            {checkerContext.checker && (
+              <>
+                <p>current checker:</p>
+                <ul>
+                  {checkerContext.checker?.permits?.map((permit: Permit) => {
+                    return <li key={permit.name}>{permit.name}</li>;
+                  })}
+                </ul>
+              </>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card backgroundColor="level2" shadow>
+          <CardContent>
+            <Heading forwardedAs="h2">useChecker</Heading>
             <Debug json={checkerContext} condensed />
-          </CardContent>
-        </Card>
-
-        <Card backgroundColor="level2" shadow>
-          <CardContent>
-            <Heading forwardedAs="h2">Topic Data</Heading>
-            <Debug json={topicData} />
-            <button
-              onClick={() =>
-                setTopicData({
-                  finishedComponents: ["locatie invoer"],
-                  activeComponents: ["vragen"],
-                  questionIndex: 0,
-                  answers: {},
-                  address: {
-                    __typename: "Address",
-                    restrictions: [
-                      {
-                        __typename: "Monument",
-                        name: "Gemeentelijk monument",
-                      },
-                    ],
-                    zoningPlans: [
-                      {
-                        __typename: "zoningPlan",
-                        name: "Paraplubestemmingsplan Stadsdeel West",
-                      },
-                      {
-                        __typename: "zoningPlan",
-                        name: "Aanpassen geluidzone Westpoort en Hoogtij",
-                      },
-                      {
-                        __typename: "zoningPlan",
-                        name: "Landlust en Gibraltarbuurt",
-                      },
-                      {
-                        __typename: "zoningPlan",
-                        name: "Drijvende bouwwerken",
-                      },
-                    ],
-                    id: "MDM2MzAxMDAxMjA2MjA2NA==",
-                    streetName: "Louise de Colignystraat",
-                    postalCode: "1055XD",
-                    houseNumber: 19,
-                    houseNumberFull: "19 C",
-                    residence: "Amsterdam",
-                    districtName: "Landlust",
-                    neighborhoodName: "Landlust Noord",
-                  },
-                })
-              }
-            >
-              update topic
-            </button>
-          </CardContent>
-        </Card>
-
-        <Card backgroundColor="level2" shadow>
-          <CardContent>
-            <Heading forwardedAs="h2">Session</Heading>
-            <Debug json={session} />
-            <button
-              onClick={() => {
-                setSession({ fake1: defaultTopicSession });
-                setSession({ fake2: defaultTopicSession });
-              }}
-            >
-              update session
-            </button>
           </CardContent>
         </Card>
 
         {topic && (
           <Card backgroundColor="level2" shadow>
             <CardContent>
-              <Heading forwardedAs="h2">Topic</Heading>
+              <Heading forwardedAs="h2">useTopic</Heading>
               <Debug json={topic} />
             </CardContent>
           </Card>
         )}
+
+        <Card backgroundColor="level2" shadow>
+          <CardContent>
+            <Heading forwardedAs="h2">useTopicData</Heading>
+            <Accordion title="Toon topicData">
+              <Debug json={topicData} />
+              <button
+                onClick={() =>
+                  setTopicData({
+                    finishedComponents: ["locatie invoer"],
+                    activeComponents: ["vragen"],
+                    questionIndex: 0,
+                    answers: {},
+                    address: {
+                      __typename: "Address",
+                      restrictions: [
+                        {
+                          __typename: "Monument",
+                          name: "Gemeentelijk monument",
+                        },
+                      ],
+                      zoningPlans: [
+                        {
+                          __typename: "zoningPlan",
+                          name: "Paraplubestemmingsplan Stadsdeel West",
+                        },
+                        {
+                          __typename: "zoningPlan",
+                          name: "Aanpassen geluidzone Westpoort en Hoogtij",
+                        },
+                        {
+                          __typename: "zoningPlan",
+                          name: "Landlust en Gibraltarbuurt",
+                        },
+                        {
+                          __typename: "zoningPlan",
+                          name: "Drijvende bouwwerken",
+                        },
+                      ],
+                      id: "MDM2MzAxMDAxMjA2MjA2NA==",
+                      streetName: "Louise de Colignystraat",
+                      postalCode: "1055XD",
+                      houseNumber: 19,
+                      houseNumberFull: "19 C",
+                      residence: "Amsterdam",
+                      districtName: "Landlust",
+                      neighborhoodName: "Landlust Noord",
+                    },
+                  })
+                }
+              >
+                update topic
+              </button>
+            </Accordion>
+          </CardContent>
+        </Card>
+
+        <Card backgroundColor="level2" shadow>
+          <CardContent>
+            <Heading forwardedAs="h2">useSession</Heading>
+            <Accordion title="Toon session">
+              <Debug json={session} />
+              <button
+                onClick={() => {
+                  setSession({ fake1: defaultTopicSession });
+                  setSession({ fake2: defaultTopicSession });
+                }}
+              >
+                update session
+              </button>
+            </Accordion>
+          </CardContent>
+        </Card>
+
+        <Card backgroundColor="level2" shadow>
+          <CardContent>
+            <Heading forwardedAs="h2">useSlug</Heading>
+            <Debug json={slug} />
+          </CardContent>
+        </Card>
 
         <Card backgroundColor="level2" shadow>
           <CardContent>
@@ -168,24 +200,6 @@ const DebugVariables: React.FC<DebugVariablesProps> = () => {
             </HiddenDebugInfo>
           </CardContent>
         </Card>
-
-        <Card backgroundColor="level2" shadow>
-          <CardContent>
-            <Heading forwardedAs="h2">useSlug</Heading>
-            <Debug json={slug} />
-          </CardContent>
-        </Card>
-
-        {checkerContext.checker && (
-          <Card backgroundColor="level2" shadow>
-            <CardContent>
-              <Heading forwardedAs="h2">permits from checkerContext</Heading>
-              {checkerContext.checker?.permits?.map((permit: Permit) => {
-                return <Paragraph key={permit.name}>{permit.name}</Paragraph>;
-              })}
-            </CardContent>
-          </Card>
-        )}
       </Accordion>
     </HiddenDebugInfo>
   );

--- a/packages/client/src/hooks/useChecker.ts
+++ b/packages/client/src/hooks/useChecker.ts
@@ -41,7 +41,7 @@ export default () => {
           `${window.location.origin}/${topicConfig.path}`
         );
         const newChecker = getChecker(await topicRequest.json());
-        const address = topicData.address;
+        const { address, answers } = topicData;
 
         // Find if we have missing data needs
         if (address) {
@@ -56,7 +56,6 @@ export default () => {
         // Restore available answers from previous session. If we have
         // an unfulfilled dataNeed we don't restore the answers to
         // prevent issues with older sessions.
-        const answers = topicData.answers;
         if (answers && !unfulfilledDataNeed) {
           newChecker.setQuestionAnswers(answers);
         }

--- a/packages/client/src/hooks/useSlug.ts
+++ b/packages/client/src/hooks/useSlug.ts
@@ -5,8 +5,6 @@ import { getSlugFromPathname } from "../utils";
 export default (): string => {
   const { pathname } = useLocation();
   const slug = getSlugFromPathname(pathname);
-  if (!slug && pathname !== "/") {
-    throw new Error(`useSlug: slug not found (${pathname})`);
-  }
+
   return slug;
 };

--- a/packages/client/src/index.tsx
+++ b/packages/client/src/index.tsx
@@ -40,8 +40,8 @@ init(sentryConfig);
 
 ReactDOM.render(
   <BrowserRouter>
-    <SessionProvider>
-      <CheckerProvider>
+    <CheckerProvider>
+      <SessionProvider>
         <ApolloProvider client={apolloClient}>
           <ThemeProvider>
             <GlobalStyle />
@@ -51,8 +51,8 @@ ReactDOM.render(
             </MatomoProvider>
           </ThemeProvider>
         </ApolloProvider>
-      </CheckerProvider>
-    </SessionProvider>
+      </SessionProvider>
+    </CheckerProvider>
   </BrowserRouter>,
 
   document.getElementById("root")

--- a/packages/client/src/pages/CheckerPage.tsx
+++ b/packages/client/src/pages/CheckerPage.tsx
@@ -21,7 +21,11 @@ import {
   useTopicData,
   useTracking,
 } from "../hooks";
-import { Address, SessionContext } from "../SessionContext";
+import {
+  Address,
+  SessionContext,
+  defaultTopicSession,
+} from "../SessionContext";
 import { isEmptyObject } from "../utils";
 import ErrorPage from "./ErrorPage";
 import LoadingPage from "./LoadingPage";
@@ -38,6 +42,7 @@ const CheckerPage = () => {
 
   const {
     activeComponents,
+    address,
     answers,
     questionIndex = 0,
     finishedComponents = [],
@@ -87,6 +92,13 @@ const CheckerPage = () => {
       setActiveState(activeStep);
       setTopicData({ finishedComponents: [] });
     }
+
+    // Prevent bug when manually erasing data Session Storage
+    if (hasDataNeeds && !address && !isActive(sections.LOCATION_INPUT)) {
+      setTopicData(defaultTopicSession);
+      setActiveState(sections.LOCATION_INPUT);
+    }
+
     // Prevent linter to add all dependencies, now the useEffect is only called on mount
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeComponents, checker, hasDataNeeds]);

--- a/packages/client/src/pages/IntroPage.tsx
+++ b/packages/client/src/pages/IntroPage.tsx
@@ -1,20 +1,16 @@
-import React, { Suspense, useContext } from "react";
+import React, { Suspense } from "react";
 import { Helmet } from "react-helmet";
 import { useHistory } from "react-router-dom";
 
-import { CheckerContext } from "../CheckerContext";
 import { TopicLayout } from "../components/Layouts";
 import Loading from "../components/Loading";
 import Nav from "../components/Nav";
-import { useSlug, useTopic, useTopicData } from "../hooks";
+import { useTopic } from "../hooks";
 import { IntroProps } from "../intros";
 import { geturl, routes } from "../routes";
 
 const IntroPage: React.FC = () => {
   const history = useHistory();
-  const checkerContext = useContext(CheckerContext);
-  const { topicData } = useTopicData();
-  const slug = useSlug();
 
   const topic = useTopic();
   const { text, intro } = topic;
@@ -25,10 +21,6 @@ const IntroPage: React.FC = () => {
   ) as IntroProps;
 
   const goToNext = () => {
-    // Unset the current checker in case the topicData contains an old checker
-    if (topicData.type !== slug) {
-      checkerContext.setChecker(undefined);
-    }
     history.push(geturl(routes.checker, topic));
   };
 

--- a/packages/client/src/utils/test-utils.tsx
+++ b/packages/client/src/utils/test-utils.tsx
@@ -25,6 +25,7 @@ window.scrollTo = jest.fn();
 
 export const mockMatomoTrackEvent = jest.fn();
 export const mockMatomoPageView = jest.fn();
+
 jest.mock("../hooks/useTracking", () => {
   return jest.fn(() => ({
     matomoTrackEvent: mockMatomoTrackEvent,
@@ -77,8 +78,8 @@ const TestProvider: React.FC<TestProviderProps> = ({
   mocks = [],
 }) => (
   <BrowserRouter>
-    <SessionProvider>
-      <CheckerProvider>
+    <CheckerProvider>
+      <SessionProvider>
         <ApolloProvider client={getTestClient(mocks)}>
           <ThemeProvider>
             <MatomoProvider value={createInstance(matomo)}>
@@ -86,8 +87,8 @@ const TestProvider: React.FC<TestProviderProps> = ({
             </MatomoProvider>
           </ThemeProvider>
         </ApolloProvider>
-      </CheckerProvider>
-    </SessionProvider>
+      </SessionProvider>
+    </CheckerProvider>
   </BrowserRouter>
 );
 


### PR DESCRIPTION
There was a bug when going to a new checker with the same address. The `setTopicData` hook function is not working there because it's going to need to set data for _another_ topic. When updating the `session` with `setSession` directly, it doesn't update the `topicData` hook data. Therefore I needed to force the the new `topicData` in `SessionContext`.

I've already tested this, but please test again by going through multiple checkers with the `NewCheckerModal`