### PR TITLE
Swapped the Modal buttons

### DIFF
--- a/packages/client/src/components/Modal.tsx
+++ b/packages/client/src/components/Modal.tsx
@@ -105,6 +105,15 @@ const Modal: React.FC<ModalProps> = ({
             <CompactThemeProvider>{children}</CompactThemeProvider>
 
             <ModalFooterButtons>
+              {showCloseButton && (
+                <ModalButton
+                  data-testid={MODAL_DECLINE_BUTTON}
+                  onClick={() => toggleModal(false)}
+                  variant="primaryInverted"
+                >
+                  {closeButtonText}
+                </ModalButton>
+              )}
               {showConfirmButton && (
                 <ModalButton
                   data-testid={MODAL_CONFIRM_BUTTON}
@@ -115,15 +124,6 @@ const Modal: React.FC<ModalProps> = ({
                   variant="primary"
                 >
                   {confirmText}
-                </ModalButton>
-              )}
-              {showCloseButton && (
-                <ModalButton
-                  data-testid={MODAL_DECLINE_BUTTON}
-                  onClick={() => toggleModal(false)}
-                  variant="primaryInverted"
-                >
-                  {closeButtonText}
                 </ModalButton>
               )}
             </ModalFooterButtons>


### PR DESCRIPTION
Swapped the Modal buttons to make it feel more natural. We saw that users expected the 'close' button to be left and the 'submit' button on the right.

(Please merge after approval.)

## New:
<img src=https://user-images.githubusercontent.com/7781865/101624454-394f6f80-3a1a-11eb-9a15-75ed95a08a31.png width=50% >

<img src=https://user-images.githubusercontent.com/7781865/101624448-38b6d900-3a1a-11eb-80a2-9a58ec10ea38.png width=50% >

## Old:
<img src=https://user-images.githubusercontent.com/7781865/101624486-44a29b00-3a1a-11eb-8f82-f485fcfa50de.png width=50% >

<img src=https://user-images.githubusercontent.com/7781865/101624480-43716e00-3a1a-11eb-85e6-1f3f6eca3544.png width=50% >
