### PR TITLE
Refactored types and React imports

### DIFF
--- a/packages/client/src/CheckerContext.tsx
+++ b/packages/client/src/CheckerContext.tsx
@@ -1,10 +1,10 @@
 import { Checker } from "@vergunningcheck/imtr-client";
-import React, { useEffect } from "react";
+import React, { FunctionComponent, useEffect } from "react";
 import { createContext, useState } from "react";
 
 import { useSlug } from "./hooks";
 
-export type setCheckerFn = (checker?: Checker) => void;
+type setCheckerFn = (checker?: Checker) => void;
 
 type CheckerContextType = {
   checker?: Checker;
@@ -23,7 +23,7 @@ type CheckerProviderProps = {
   defaultChecker?: Checker;
 };
 
-export const CheckerProvider: React.FC<CheckerProviderProps> = ({
+export const CheckerProvider: FunctionComponent<CheckerProviderProps> = ({
   children,
   defaultChecker = undefined,
 }) => {
@@ -31,7 +31,7 @@ export const CheckerProvider: React.FC<CheckerProviderProps> = ({
   const slug = useSlug();
 
   useEffect(() => {
-    // The slug changed, so uncheck the current checker
+    // The slug changed, so unload the current checker
     setChecker(undefined);
   }, [slug]);
 

--- a/packages/client/src/SessionContext.tsx
+++ b/packages/client/src/SessionContext.tsx
@@ -1,45 +1,15 @@
-import { Answer } from "@vergunningcheck/imtr-client";
-import React, { useEffect, useReducer } from "react";
+import React, { FunctionComponent, useEffect, useReducer } from "react";
 import { createContext } from "react";
 
 import { useSlug } from "./hooks";
+import { SessionData, TopicData, setSessionFn, setTopicFn } from "./types";
 import { findTopicBySlug } from "./utils";
 
-// @TODO: All these types are going to be moved from this file when we merge this with `checker-slopen`
-export type Restriction = {
-  __typename?: string;
-  name?: string;
-  scope?: string;
-};
-export type ZoningPlan = {
-  __typename?: string;
-  name?: string;
-  scope?: string;
-};
-export type AddressType = {
-  __typename?: string;
-  districtName: string;
-  houseNumber: number;
-  houseNumberFull: string;
-  id: string;
-  neighborhoodName: string;
-  postalCode: string;
-  residence: string;
-  restrictions: Restriction[];
-  streetName: string;
-  zoningPlans: ZoningPlan[];
-};
-export type Address = null | AddressType;
-
-export type TopicData = {
-  activeComponents?: string[];
-  address: Address;
-  answers: {
-    [id: string]: Answer;
-  };
-  finishedComponents: string[];
-  type: string;
-  questionIndex: number;
+type AppSessionContext = {
+  session: SessionData;
+  setSession: setSessionFn;
+  setTopicData: setTopicFn;
+  topicData: TopicData;
 };
 
 export const defaultTopicSession: TopicData = {
@@ -49,24 +19,6 @@ export const defaultTopicSession: TopicData = {
   finishedComponents: [],
   questionIndex: 0,
   type: "",
-};
-
-export type setTopicFn = (topicData: Partial<TopicData>) => void;
-export type setSessionFn = (sessionData: Partial<SessionData>) => void;
-
-export type SessionData = {
-  [slug: string]: null | TopicData;
-};
-
-export type setTopicSessionDataFn = (
-  topicData: null | Partial<TopicData>
-) => void;
-
-type AppSessionContext = {
-  session: SessionData;
-  setSession: setSessionFn;
-  setTopicData: setTopicFn;
-  topicData: TopicData;
 };
 
 const session = JSON.parse(sessionStorage.getItem("sessionData") as string);
@@ -99,7 +51,7 @@ export const topicReducer = (
   };
 };
 
-export const SessionProvider: React.FC = ({ children }) => {
+export const SessionProvider: FunctionComponent = ({ children }) => {
   // We use the reducer to take care of too complex logic for setState.
   // Because we sometimes need to clear the sessionStorage.
   const [session, setSession] = useReducer(sessionReducer, startSession);

--- a/packages/client/src/__mocks__/context.tsx
+++ b/packages/client/src/__mocks__/context.tsx
@@ -1,12 +1,12 @@
 import { Answers, Checker } from "@vergunningcheck/imtr-client";
-import React from "react";
+import React, { FunctionComponent } from "react";
 import { useContext } from "react";
 
 import { CheckerContext } from "../CheckerContext";
-import { Topic } from "../config";
-import { Address, SessionContext } from "../SessionContext";
+import { SessionContext } from "../SessionContext";
+import { Address, Topic } from "../types";
 
-type Props = {
+type SessionContextProviderProps = {
   addressMock?: Address;
   answers?: Answers;
   checker?: Checker;
@@ -14,7 +14,7 @@ type Props = {
   topicMock: Topic;
 };
 
-const SessionContextProvider: React.FC<Props> = ({
+const SessionContextProvider: FunctionComponent<SessionContextProviderProps> = ({
   addressMock,
   answers: answersMock,
   checker,

--- a/packages/client/src/atoms/EditButton.tsx
+++ b/packages/client/src/atoms/EditButton.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@amsterdam/asc-ui";
-import React from "react";
+import React, { FunctionComponent, HTMLAttributes } from "react";
 import styled from "styled-components";
 
 import { EDIT_BUTTON } from "../utils/test-ids";
@@ -14,10 +14,8 @@ const EditButtonStyle = styled(Button)`
   }
 `;
 
-const EditButton: React.FC<
-  { dataTestid?: string; disabled?: boolean } & React.HTMLAttributes<
-    HTMLElement
-  >
+const EditButton: FunctionComponent<
+  { dataTestid?: string; disabled?: boolean } & HTMLAttributes<HTMLElement>
 > = ({ dataTestid = EDIT_BUTTON, disabled = false, onClick }) => (
   <EditButtonStyle
     data-testid={dataTestid}

--- a/packages/client/src/atoms/PrevButton.tsx
+++ b/packages/client/src/atoms/PrevButton.tsx
@@ -1,5 +1,5 @@
 import { Button, themeSpacing } from "@amsterdam/asc-ui";
-import React from "react";
+import React, { FunctionComponent, HTMLAttributes } from "react";
 import styled from "styled-components";
 
 import { PREV_BUTTON } from "../utils/test-ids";
@@ -9,7 +9,7 @@ const PrevButtonStyle = styled(Button)`
   align-self: center;
 `;
 
-const PrevButton: React.FC<React.HTMLAttributes<HTMLElement>> = ({
+const PrevButton: FunctionComponent<HTMLAttributes<HTMLElement>> = ({
   children,
   onClick,
 }) => (

--- a/packages/client/src/atoms/PrintOnly.tsx
+++ b/packages/client/src/atoms/PrintOnly.tsx
@@ -4,7 +4,7 @@ import styled, { css } from "styled-components";
 import { printOnly } from "../utils/themeUtils";
 import { avoidPageBreak } from "../utils/themeUtils";
 
-export type PrintOnlyProps = {
+type PrintOnlyProps = {
   avoidPageBreak?: boolean;
   withBorder?: boolean;
 };

--- a/packages/client/src/atoms/TextToEdit.tsx
+++ b/packages/client/src/atoms/TextToEdit.tsx
@@ -1,5 +1,5 @@
 import { themeSpacing } from "@amsterdam/asc-ui";
-import React from "react";
+import React, { FunctionComponent, HTMLAttributes } from "react";
 import styled from "styled-components";
 
 import { TEXT_TO_EDIT_BUTTON } from "../utils/test-ids";
@@ -8,7 +8,7 @@ const TextToEditStyle = styled.span`
   margin-right: ${themeSpacing(5)};
 `;
 
-const TextToEdit: React.FC<React.HTMLAttributes<HTMLElement>> = ({
+const TextToEdit: FunctionComponent<HTMLAttributes<HTMLElement>> = ({
   children,
 }) => (
   <TextToEditStyle data-testid={TEXT_TO_EDIT_BUTTON}>

--- a/packages/client/src/components/AddressLines.tsx
+++ b/packages/client/src/components/AddressLines.tsx
@@ -2,7 +2,7 @@ import { Paragraph } from "@amsterdam/asc-ui";
 import React from "react";
 
 import { TextToEdit } from "../atoms";
-import { Address } from "../SessionContext";
+import { Address } from "../types";
 
 type AddressLinesProps = {
   address: Address;

--- a/packages/client/src/components/Answers.tsx
+++ b/packages/client/src/components/Answers.tsx
@@ -1,6 +1,6 @@
 import { ErrorMessage, Radio, RadioGroup } from "@amsterdam/asc-ui";
 import { removeQuotes } from "@vergunningcheck/imtr-client";
-import React from "react";
+import React, { FormEvent, FunctionComponent } from "react";
 
 import { ComponentWrapper, Label } from "../atoms";
 import { QUESTION_ANSWERS } from "../utils/test-ids";
@@ -11,16 +11,16 @@ export type AnswerProps = {
   value: boolean | string;
 };
 
-export type AnswersProps = {
+type AnswersProps = {
   answers?: AnswerProps[];
   errors: any;
-  onChange: (e: React.FormEvent<HTMLInputElement>) => void;
+  onChange: (e: FormEvent<HTMLInputElement>) => void;
   questionId: string;
   questionIndex: number;
   userAnswer?: string;
 };
 
-const Answers: React.FC<AnswersProps> = ({
+const Answers: FunctionComponent<AnswersProps> = ({
   answers,
   errors,
   onChange,

--- a/packages/client/src/components/AutoSuggestList.tsx
+++ b/packages/client/src/components/AutoSuggestList.tsx
@@ -1,6 +1,12 @@
 import { ChevronRight } from "@amsterdam/asc-assets";
 import { Icon, themeColor, themeSpacing } from "@amsterdam/asc-ui";
-import React, { Fragment, useCallback, useEffect, useRef } from "react";
+import React, {
+  Fragment,
+  FunctionComponent,
+  useCallback,
+  useEffect,
+  useRef,
+} from "react";
 import styled from "styled-components";
 
 import { AUTOSUGGEST_ITEM, AUTOSUGGEST_LIST } from "../utils/test-ids";
@@ -40,7 +46,7 @@ const StyledIcon = styled(Icon)`
   display: inline-block;
 `;
 
-const SuggestList: React.FC<{
+const SuggestList: FunctionComponent<{
   activeIndex: number;
   className?: string;
   onSelectOption: (option: Option) => void;

--- a/packages/client/src/components/Conclusion/Conclusion.tsx
+++ b/packages/client/src/components/Conclusion/Conclusion.tsx
@@ -1,6 +1,6 @@
 import { themeSpacing } from "@amsterdam/asc-ui";
 import { imtrOutcomes } from "@vergunningcheck/imtr-client";
-import React from "react";
+import React, { FunctionComponent } from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 
@@ -18,7 +18,7 @@ const ConclusionWrapper = styled.div`
 `;
 const { NEED_CONTACT, NEED_PERMIT, PERMIT_FREE } = imtrOutcomes;
 
-const Conclusion: React.FC = () => {
+const Conclusion: FunctionComponent = () => {
   const { checker } = useChecker();
   const { t } = useTranslation();
 

--- a/packages/client/src/components/Conclusion/ConclusionOutcome.tsx
+++ b/packages/client/src/components/Conclusion/ConclusionOutcome.tsx
@@ -1,6 +1,6 @@
 import { Heading, themeSpacing } from "@amsterdam/asc-ui";
 import { imtrOutcomes } from "@vergunningcheck/imtr-client";
-import React, { ReactNode, useEffect } from "react";
+import React, { FunctionComponent, ReactNode, useEffect } from "react";
 import { isIE, isMobile } from "react-device-detect";
 import styled, { css } from "styled-components";
 
@@ -34,7 +34,7 @@ type ConclusionOutcomeProps = {
   showDiscaimer?: boolean;
 };
 
-const ConclusionOutcome: React.FC<ConclusionOutcomeProps> = ({
+const ConclusionOutcome: FunctionComponent<ConclusionOutcomeProps> = ({
   conclusionContent,
   outcomeType,
   showDiscaimer,

--- a/packages/client/src/components/Conclusion/NeedPermitContent.tsx
+++ b/packages/client/src/components/Conclusion/NeedPermitContent.tsx
@@ -1,5 +1,5 @@
 import { Button, Link, Paragraph } from "@amsterdam/asc-ui";
-import React from "react";
+import React, { FunctionComponent } from "react";
 
 import { HideForPrint, PrintOnly } from "../../atoms";
 import ComponentWrapper from "../../atoms/ComponentWrapper";
@@ -8,7 +8,7 @@ import { actions, eventNames } from "../../config/matomo";
 import { useTracking } from "../../hooks";
 import { NEED_PERMIT_BUTTON } from "../../utils/test-ids";
 
-const NeedPermitContent: React.FC = () => {
+const NeedPermitContent: FunctionComponent = () => {
   const { matomoTrackEvent } = useTracking();
   const handlePermitInfoButton = () => {
     matomoTrackEvent({

--- a/packages/client/src/components/Conclusion/NewCheckerModal.test.tsx
+++ b/packages/client/src/components/Conclusion/NewCheckerModal.test.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 
 import addressGraphQLMock from "../../__mocks__/address";
-import { Topic } from "../../config";
 import { actions, eventNames } from "../../config/matomo";
+import { Topic } from "../../types";
 import { findTopicBySlug } from "../../utils";
 import {
   MODAL,

--- a/packages/client/src/components/Conclusion/NewCheckerModal.tsx
+++ b/packages/client/src/components/Conclusion/NewCheckerModal.tsx
@@ -1,5 +1,5 @@
 import { ErrorMessage, Paragraph, Radio, RadioGroup } from "@amsterdam/asc-ui";
-import React, { useContext, useState } from "react";
+import React, { FunctionComponent, useContext, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";
 
@@ -17,7 +17,7 @@ import {
 } from "../../utils/test-ids";
 import Modal from "../Modal";
 
-const NewCheckerModal: React.FC = () => {
+const NewCheckerModal: FunctionComponent = () => {
   const { matomoTrackEvent } = useTracking();
   const { topicData, setTopicData } = useTopicData();
   const slug = useSlug();

--- a/packages/client/src/components/Conclusion/NoPermitDescription.tsx
+++ b/packages/client/src/components/Conclusion/NoPermitDescription.tsx
@@ -1,10 +1,10 @@
 import { Heading, ListItem, Paragraph } from "@amsterdam/asc-ui";
-import React from "react";
+import React, { FunctionComponent } from "react";
 
 import { List } from "../../atoms/index";
 import { NO_PERMIT_NEEDED } from "../../utils/test-ids";
 
-const NoPermitDescription: React.FC = () => (
+const NoPermitDescription: FunctionComponent = () => (
   <>
     <Paragraph data-testid={NO_PERMIT_NEEDED}>
       U moet wel op een aantal dingen letten voordat u gaat beginnen. Uw

--- a/packages/client/src/components/Disclaimer.tsx
+++ b/packages/client/src/components/Disclaimer.tsx
@@ -1,10 +1,10 @@
 import { CompactThemeProvider, Paragraph } from "@amsterdam/asc-ui";
-import React from "react";
+import React, { FunctionComponent } from "react";
 import { useTranslation } from "react-i18next";
 
 import { DISCLAIMER_TEXT } from "../utils/test-ids";
 
-const Disclaimer: React.FC = () => {
+const Disclaimer: FunctionComponent = () => {
   const { t } = useTranslation();
   return (
     <CompactThemeProvider>

--- a/packages/client/src/components/Error.tsx
+++ b/packages/client/src/components/Error.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { FunctionComponent } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Alert, ComponentWrapper } from "../atoms";
@@ -9,7 +9,12 @@ type ErrorProps = {
   stack?: string;
 };
 
-const Error: React.FC<ErrorProps> = ({ children, content, heading, stack }) => {
+const Error: FunctionComponent<ErrorProps> = ({
+  children,
+  content,
+  heading,
+  stack,
+}) => {
   const { t } = useTranslation();
   return (
     <ComponentWrapper>

--- a/packages/client/src/components/Form.tsx
+++ b/packages/client/src/components/Form.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { FunctionComponent, HTMLAttributes } from "react";
 
 import { StyledForm } from "./FormStyles";
 
@@ -7,7 +7,7 @@ type FormProps = {
   dataTestId?: string;
 };
 
-const Form: React.FC<FormProps & React.HTMLAttributes<HTMLElement>> = ({
+const Form: FunctionComponent<FormProps & HTMLAttributes<HTMLElement>> = ({
   children,
   dataId,
   dataTestId = "form",

--- a/packages/client/src/components/Header.tsx
+++ b/packages/client/src/components/Header.tsx
@@ -13,7 +13,7 @@ import {
 export const Header = () => {
   const { matomoTrackEvent } = useTracking();
 
-  const handleClick = (e: React.MouseEvent<HTMLElement, MouseEvent>) => {
+  const handleClick = () => {
     matomoTrackEvent({
       action: actions.CLICK_EXTERNAL_NAVIGATION,
       name: `${eventNames.LOGO} - ${sections.HEADER}`,

--- a/packages/client/src/components/HiddenDebugInfo.tsx
+++ b/packages/client/src/components/HiddenDebugInfo.tsx
@@ -1,9 +1,9 @@
 /* istanbul ignore file */
-import React from "react";
+import React, { FunctionComponent, HTMLAttributes } from "react";
 
 import { HiddenDiv } from "./HiddenDebugInfoStyles";
 
-const HiddenDebugInfo: React.FC<React.HTMLAttributes<HTMLElement>> = ({
+const HiddenDebugInfo: FunctionComponent<HTMLAttributes<HTMLElement>> = ({
   children,
   style,
 }) => (

--- a/packages/client/src/components/Layouts/BaseLayout.tsx
+++ b/packages/client/src/components/Layouts/BaseLayout.tsx
@@ -1,5 +1,5 @@
 import { Column, Row } from "@amsterdam/asc-ui";
-import React, { useEffect } from "react";
+import React, { FunctionComponent, useEffect } from "react";
 import { Helmet } from "react-helmet";
 import { useHistory } from "react-router-dom";
 
@@ -13,7 +13,7 @@ type BaseLayoutProps = {
   disablePageView?: boolean;
 };
 
-const BaseLayout: React.FC<BaseLayoutProps> = ({
+const BaseLayout: FunctionComponent<BaseLayoutProps> = ({
   children,
   disablePageView,
 }) => {

--- a/packages/client/src/components/Layouts/TopicLayout.test.tsx
+++ b/packages/client/src/components/Layouts/TopicLayout.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { Topic } from "../../config";
+import { Topic } from "../../types";
 import { findTopicBySlug } from "../../utils";
 import { render, screen } from "../../utils/test-utils";
 import TopicLayout from "./TopicLayout";

--- a/packages/client/src/components/Layouts/TopicLayout.tsx
+++ b/packages/client/src/components/Layouts/TopicLayout.tsx
@@ -1,5 +1,5 @@
 import { FormTitle, Heading } from "@amsterdam/asc-ui";
-import React from "react";
+import React, { FunctionComponent } from "react";
 
 import { HideForPrint } from "../../atoms";
 import { DebugVariables } from "../../debug";
@@ -11,7 +11,7 @@ interface TopicLayoutProps {
   formTitle?: string;
 }
 
-const TopicLayout: React.FC<TopicLayoutProps> = ({
+const TopicLayout: FunctionComponent<TopicLayoutProps> = ({
   children,
   heading: headingProp,
   formTitle: formTitleProp,

--- a/packages/client/src/components/Link.tsx
+++ b/packages/client/src/components/Link.tsx
@@ -1,12 +1,12 @@
 import { Link as StyledComponentLink } from "@amsterdam/asc-ui";
-import React from "react";
+import React, { ReactNode } from "react";
 
 import { actions } from "../config/matomo";
 import { useTracking } from "../hooks";
 
 type Props = {
   action?: string;
-  children: React.ReactNode;
+  children: ReactNode;
   darkBackground?: boolean;
   href?: string;
   eventName: string;

--- a/packages/client/src/components/Location/EditLocationModal.tsx
+++ b/packages/client/src/components/Location/EditLocationModal.tsx
@@ -1,5 +1,5 @@
 import { Paragraph } from "@amsterdam/asc-ui";
-import React from "react";
+import React, { FunctionComponent } from "react";
 
 import { ComponentWrapper, EditButton } from "../../atoms";
 import { actions, eventNames } from "../../config/matomo";
@@ -8,7 +8,7 @@ import { defaultTopicSession } from "../../SessionContext";
 import { LOCATION_MODAL_OPEN_BUTTON } from "../../utils/test-ids";
 import Modal from "../Modal";
 
-const EditLocationModal: React.FC = () => {
+const EditLocationModal: FunctionComponent = () => {
   const { matomoTrackEvent } = useTracking();
   const { setChecker } = useChecker();
   const { setTopicData } = useTopicData();

--- a/packages/client/src/components/Location/LocationFinder.test.tsx
+++ b/packages/client/src/components/Location/LocationFinder.test.tsx
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom/extend-expect";
 
-import React from "react";
+import React, { useState } from "react";
 
 import locationFinderGraphQLMocks from "../../__mocks__/locationFinderGraphQLMocks";
 import text from "../../i18n/nl";
@@ -36,7 +36,7 @@ describe("LocationFinder", () => {
   const topic = findTopicBySlug("dakkapel-plaatsen");
 
   const Wrapper = () => {
-    const [focus, setFocus] = React.useState(false);
+    const [focus, setFocus] = useState(false);
 
     return (
       <LocationFinder

--- a/packages/client/src/components/Location/LocationFinder.tsx
+++ b/packages/client/src/components/Location/LocationFinder.tsx
@@ -1,14 +1,19 @@
 import { ErrorMessage, Paragraph } from "@amsterdam/asc-ui";
 import { ApolloError, useQuery } from "@apollo/client";
 import { loader } from "graphql.macro";
-import React, { useCallback, useEffect, useState } from "react";
+import React, {
+  FunctionComponent,
+  useCallback,
+  useEffect,
+  useState,
+} from "react";
 import { useTranslation } from "react-i18next";
 
 import { Alert, ComponentWrapper } from "../../atoms";
 import { actions, eventNames } from "../../config/matomo";
 import { useTopicData, useTracking } from "../../hooks";
 import useDebounce from "../../hooks/useDebounce";
-import { Address } from "../../SessionContext";
+import { Address } from "../../types";
 import { isValidPostalcode, stripString } from "../../utils";
 import { LOCATION_FOUND } from "../../utils/test-ids";
 import AutoSuggestList, { Option } from "../AutoSuggestList";
@@ -37,7 +42,7 @@ type LocationFinderProps = {
   setFocus: (focus: boolean) => void;
 };
 
-const LocationFinder: React.FC<LocationFinderProps> = ({
+const LocationFinder: FunctionComponent<LocationFinderProps> = ({
   errorMessage,
   focus,
   sessionAddress,

--- a/packages/client/src/components/Location/LocationInput.tsx
+++ b/packages/client/src/components/Location/LocationInput.tsx
@@ -8,7 +8,7 @@ import { useHistory } from "react-router-dom";
 import { actions, eventNames, sections } from "../../config/matomo";
 import { useTopic, useTopicData, useTracking } from "../../hooks";
 import { geturl, routes } from "../../routes";
-import { Address } from "../../SessionContext";
+import { Address } from "../../types";
 import { getRestrictionByTypeName } from "../../utils";
 import Error from "../Error";
 import Form from "../Form";

--- a/packages/client/src/components/Location/LocationLoading.tsx
+++ b/packages/client/src/components/Location/LocationLoading.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { FunctionComponent } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Alert, ComponentWrapper } from "../../atoms";
@@ -7,7 +7,9 @@ type LocationLoadingProps = {
   loading: boolean;
 };
 
-const LocationLoading: React.FC<LocationLoadingProps> = ({ loading }) => {
+const LocationLoading: FunctionComponent<LocationLoadingProps> = ({
+  loading,
+}) => {
   const { t } = useTranslation();
   if (!loading) return null;
   return (

--- a/packages/client/src/components/Location/LocationNotFound.tsx
+++ b/packages/client/src/components/Location/LocationNotFound.tsx
@@ -1,5 +1,5 @@
 import { Paragraph } from "@amsterdam/asc-ui";
-import React, { useEffect } from "react";
+import React, { FunctionComponent, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Alert, ComponentWrapper } from "../../atoms";
@@ -8,7 +8,7 @@ import { useTracking } from "../../hooks";
 import { LOCATION_NOT_FOUND } from "../../utils/test-ids";
 import PhoneNumber from "../PhoneNumber";
 
-const LocationNotFound: React.FC = () => {
+const LocationNotFound: FunctionComponent = () => {
   const { matomoTrackEvent } = useTracking();
   const { t } = useTranslation();
 

--- a/packages/client/src/components/Location/LocationSummary.test.tsx
+++ b/packages/client/src/components/Location/LocationSummary.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { ComponentProps } from "react";
 
 import addressMock from "../../__mocks__/addressMock";
 import addressMockNoMonument from "../../__mocks__/addressMockNoMonument";
@@ -18,7 +18,7 @@ jest.mock("react-router-dom", () => ({
 
 describe("LocationSummary", () => {
   const WrapperWithContext = (
-    props: React.ComponentProps<typeof LocationSummary>
+    props: ComponentProps<typeof LocationSummary>
   ) => (
     <CheckerProvider>
       <LocationSummary {...props} />

--- a/packages/client/src/components/Location/LocationSummary.tsx
+++ b/packages/client/src/components/Location/LocationSummary.tsx
@@ -1,11 +1,11 @@
 import { Paragraph, themeColor, themeSpacing } from "@amsterdam/asc-ui";
 import { setTag } from "@sentry/browser";
-import React from "react";
+import React, { FunctionComponent } from "react";
 import styled, { css } from "styled-components";
 
 import { ComponentWrapper, List, ListItem } from "../../atoms";
 import { useTopic, useTopicData } from "../../hooks";
-import { Address } from "../../SessionContext";
+import { Address } from "../../types";
 import { getRestrictionByTypeName } from "../../utils";
 import {
   LOCATION_RESTRICTION_CITYSCAPE,
@@ -51,7 +51,7 @@ type LocationSummaryProps = {
   showTitle?: boolean;
 };
 
-const LocationSummary: React.FC<LocationSummaryProps> = ({
+const LocationSummary: FunctionComponent<LocationSummaryProps> = ({
   addressFromLocation,
   isBelowInputFields,
   showEditLocationModal,

--- a/packages/client/src/components/Markdown/index.tsx
+++ b/packages/client/src/components/Markdown/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { FunctionComponent } from "react";
 import ReactMarkdown from "react-markdown";
 
 import { ListItem } from "../../atoms";
@@ -12,7 +12,10 @@ type MarkDownProps = {
   source?: string;
 };
 
-const Markdown: React.FC<MarkDownProps> = ({ eventLocation, source }) => (
+const Markdown: FunctionComponent<MarkDownProps> = ({
+  eventLocation,
+  source,
+}) => (
   <ReactMarkdown
     source={source}
     renderers={{

--- a/packages/client/src/components/Markdown/renderers/BlockRenderer.tsx
+++ b/packages/client/src/components/Markdown/renderers/BlockRenderer.tsx
@@ -1,9 +1,9 @@
-import React from "react";
+import React, { ReactChildren } from "react";
 
 import { StyledParagraph } from "./BlockRendererStyles";
 
 type Props = {
-  children: React.ReactChildren;
+  children: ReactChildren;
 };
 
 /**

--- a/packages/client/src/components/Markdown/renderers/LinkRenderer.tsx
+++ b/packages/client/src/components/Markdown/renderers/LinkRenderer.tsx
@@ -1,10 +1,10 @@
-import React from "react";
+import React, { ReactChildren } from "react";
 
 import { actions } from "../../../config/matomo";
 import Link from "../../Link";
 
 type LinkRendererProps = {
-  children: React.ReactChildren;
+  children: ReactChildren;
   eventLocation: string;
   href: string;
 };

--- a/packages/client/src/components/Markdown/renderers/ListRenderer.tsx
+++ b/packages/client/src/components/Markdown/renderers/ListRenderer.tsx
@@ -1,8 +1,8 @@
-import React from "react";
+import React, { FunctionComponent } from "react";
 
 import { List } from "../../../atoms";
 
-const ListRenderer: React.FC = ({ children }) => (
+const ListRenderer: FunctionComponent = ({ children }) => (
   <List variant="bullet">{children}</List>
 );
 

--- a/packages/client/src/components/Modal.tsx
+++ b/packages/client/src/components/Modal.tsx
@@ -1,6 +1,6 @@
 import { Close } from "@amsterdam/asc-assets";
 import { CompactThemeProvider, Divider, Icon, TopBar } from "@amsterdam/asc-ui";
-import React, { useState } from "react";
+import React, { FunctionComponent, MouseEvent, useState } from "react";
 
 import {
   MODAL,
@@ -32,7 +32,7 @@ type ModalProps = {
   showConfirmButton?: boolean;
 };
 
-const Modal: React.FC<ModalProps> = ({
+const Modal: FunctionComponent<ModalProps> = ({
   children,
   closeButtonText = "Sluiten",
   closeModalAfterConfirm = true,
@@ -84,7 +84,7 @@ const Modal: React.FC<ModalProps> = ({
               {heading}
               <ModalButton
                 data-testid={MODAL_CLOSE_BUTTON}
-                onClick={(e: React.MouseEvent) => {
+                onClick={(e: MouseEvent) => {
                   e.stopPropagation();
                   toggleModal(false);
                 }}

--- a/packages/client/src/components/Nav.tsx
+++ b/packages/client/src/components/Nav.tsx
@@ -1,5 +1,5 @@
 import { ChevronLeft } from "@amsterdam/asc-assets";
-import React from "react";
+import React, { FormEvent, FunctionComponent } from "react";
 
 import { PrevButton } from "../atoms";
 import { NEXT_BUTTON } from "../utils/test-ids";
@@ -9,14 +9,14 @@ export type NavProps = {
   formEnds?: boolean;
   nextText?: string;
   noMarginBottom?: boolean;
-  onGoToNext?: (event: React.FormEvent) => void;
-  onGoToPrev?: (event: React.FormEvent) => void;
+  onGoToNext?: (event: FormEvent) => void;
+  onGoToPrev?: (event: FormEvent) => void;
   prevText?: string;
   showNext?: boolean;
   showPrev?: boolean;
 };
 
-const Nav: React.FC<NavProps> = ({
+const Nav: FunctionComponent<NavProps> = ({
   formEnds,
   nextText = "Volgende",
   noMarginBottom,

--- a/packages/client/src/components/PhoneNumber.tsx
+++ b/packages/client/src/components/PhoneNumber.tsx
@@ -9,7 +9,7 @@ const Wrapper = styled.span`
   white-space: nowrap;
 `;
 
-export type Props = {
+type Props = {
   darkBackground?: boolean;
   eventName: string;
   href?: string;

--- a/packages/client/src/components/Question.tsx
+++ b/packages/client/src/components/Question.tsx
@@ -1,11 +1,12 @@
 import { Question as ImtrQuestion } from "@vergunningcheck/imtr-client";
-import React, { useEffect } from "react";
+import React, { FormEvent, FunctionComponent, useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 
 import { ComponentWrapper } from "../atoms";
 import { actions, eventNames } from "../config/matomo";
 import { useTracking } from "../hooks";
+import { BooleanOption } from "../types";
 import { QUESTION_FORM } from "../utils/test-ids";
 import Answers, { AnswerProps } from "./Answers";
 import Form from "./Form";
@@ -13,12 +14,6 @@ import Markdown from "./Markdown";
 import Modal from "./Modal";
 import Nav from "./Nav";
 import QuestionAlert from "./QuestionAlert";
-
-export type BooleanOption = {
-  formValue: string;
-  label: string;
-  value: boolean;
-};
 
 export const booleanOptions: BooleanOption[] = [
   {
@@ -46,7 +41,7 @@ type QuestionProps = {
   userAnswer?: string;
 };
 
-const Question: React.FC<QuestionProps> = ({
+const Question: FunctionComponent<QuestionProps> = ({
   question,
   questionIndex,
   questionNeedsContactExit,
@@ -108,7 +103,7 @@ const Question: React.FC<QuestionProps> = ({
     requiredFieldRadio,
   ]);
 
-  const handleChange = (e: React.FormEvent) => {
+  const handleChange = (e: FormEvent) => {
     const { name, type, value } = e.target as HTMLInputElement;
 
     // Save the changed answer to the question.

--- a/packages/client/src/components/QuestionAlert.tsx
+++ b/packages/client/src/components/QuestionAlert.tsx
@@ -1,15 +1,15 @@
 import { Paragraph } from "@amsterdam/asc-ui";
-import React from "react";
+import React, { FunctionComponent } from "react";
 
 import { Alert, HideForPrint } from "../atoms";
 import { QUESTION_ALERT } from "../utils/test-ids";
 
-export type QuestionAlertProps = {
+type QuestionAlertProps = {
   marginBottom?: number;
   questionNeedsContactExit?: Boolean;
 };
 
-const QuestionAlert: React.FC<QuestionAlertProps> = ({
+const QuestionAlert: FunctionComponent<QuestionAlertProps> = ({
   marginBottom,
   questionNeedsContactExit,
 }) => (

--- a/packages/client/src/components/QuestionAnswer.tsx
+++ b/packages/client/src/components/QuestionAnswer.tsx
@@ -1,6 +1,6 @@
 import { Paragraph } from "@amsterdam/asc-ui";
 import { removeQuotes } from "@vergunningcheck/imtr-client";
-import React from "react";
+import React, { FunctionComponent, HTMLAttributes } from "react";
 
 import { EditButton, TextToEdit } from "../atoms";
 import { EDIT_BUTTON } from "../utils/test-ids";
@@ -13,8 +13,8 @@ type QuestionAnswerProps = {
   userAnswer: string;
 };
 
-const QuestionAnswer: React.FC<
-  QuestionAnswerProps & React.HTMLAttributes<HTMLElement>
+const QuestionAnswer: FunctionComponent<
+  QuestionAnswerProps & HTMLAttributes<HTMLElement>
 > = ({
   disabled,
   onClick,

--- a/packages/client/src/components/Questions.tsx
+++ b/packages/client/src/components/Questions.tsx
@@ -7,21 +7,29 @@ import {
   imtrOutcomes,
   removeQuotes,
 } from "@vergunningcheck/imtr-client";
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, {
+  FunctionComponent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 
 import { ScrollAnchor } from "../atoms";
 import { eventNames, sections } from "../config/matomo";
 import { useChecker, useTopic, useTracking } from "../hooks";
 import useTopicSession from "../hooks/useTopicData";
+import { BooleanOption } from "../types";
 import { scrollToRef } from "../utils";
-import Question, { BooleanOption, booleanOptions } from "./Question";
+import Question, { booleanOptions } from "./Question";
 import QuestionAnswer from "./QuestionAnswer";
 import { StepByStepItem } from "./StepByStepNavigation";
 
 export type GoToQuestionProp = "next" | "prev" | number;
 
 type BoolFunctionProp = (component: string, value?: boolean) => boolean;
-export type CheckerPageProps = {
+
+type QuestionsProps = {
   goToQuestion: (value: GoToQuestionProp) => void;
   isActive: BoolFunctionProp;
   isFinished: BoolFunctionProp;
@@ -38,7 +46,7 @@ export const getUserAnswer = (question: ImtrQuestion) => {
   return question.answer;
 };
 
-const Questions: React.FC<CheckerPageProps> = ({
+const Questions: FunctionComponent<QuestionsProps> = ({
   goToQuestion,
   isActive,
   isFinished,

--- a/packages/client/src/components/StepByStepNavigation/StepByStepItem.tsx
+++ b/packages/client/src/components/StepByStepNavigation/StepByStepItem.tsx
@@ -1,5 +1,10 @@
 import { Checkmark } from "@amsterdam/asc-assets";
-import React from "react";
+import React, {
+  AnchorHTMLAttributes,
+  FunctionComponent,
+  HTMLAttributes,
+  MouseEvent,
+} from "react";
 import { StyledProps } from "styled-components";
 
 import { STEPBYSTEPITEM } from "../../utils/test-ids";
@@ -8,12 +13,29 @@ import StepByStepItemStyle, {
   CircleStyle,
   CircleWrapperStyle,
   ContentWrapperStyle,
-  Props,
 } from "./StepByStepItemStyle";
 import StepByStepTitle from "./StepByStepTitle";
 
-const StepByStepItem: React.FC<
-  Props & React.HTMLAttributes<HTMLElement> & StyledProps<any>
+export type StepByStepItemProps = {
+  active?: boolean;
+  checked?: boolean;
+  circleBackgroundColor?: string;
+  clickable?: boolean;
+  customSize?: boolean;
+  disabled?: boolean;
+  disabledTextColor?: string;
+  done?: boolean;
+  doneTextColor?: string;
+  heading?: string;
+  headingProps?: any;
+  highlightActive?: boolean;
+  largeCircle?: boolean;
+  small?: boolean;
+} & AnchorHTMLAttributes<HTMLAnchorElement> &
+  HTMLAttributes<HTMLDivElement>;
+
+const StepByStepItem: FunctionComponent<
+  StepByStepItemProps & HTMLAttributes<HTMLElement> & StyledProps<any>
 > = ({
   active,
   checked,
@@ -45,7 +67,7 @@ const StepByStepItem: React.FC<
   const small = (!customSize && !active) || (customSize && !largeCircle);
 
   // @TODO: also enable the ENTER key to act as onClick
-  const handleOnClick = (event: React.MouseEvent<HTMLElement, MouseEvent>) => {
+  const handleOnClick = (event: MouseEvent<HTMLElement, MouseEvent>) => {
     onClick && onClick(event);
   };
 

--- a/packages/client/src/components/StepByStepNavigation/StepByStepItem.tsx
+++ b/packages/client/src/components/StepByStepNavigation/StepByStepItem.tsx
@@ -31,11 +31,13 @@ export type StepByStepItemProps = {
   highlightActive?: boolean;
   largeCircle?: boolean;
   small?: boolean;
-} & AnchorHTMLAttributes<HTMLAnchorElement> &
-  HTMLAttributes<HTMLDivElement>;
+};
 
 const StepByStepItem: FunctionComponent<
-  StepByStepItemProps & HTMLAttributes<HTMLElement> & StyledProps<any>
+  StepByStepItemProps &
+    AnchorHTMLAttributes<HTMLAnchorElement> &
+    HTMLAttributes<HTMLDivElement> &
+    StyledProps<any>
 > = ({
   active,
   checked,

--- a/packages/client/src/components/StepByStepNavigation/StepByStepItemStyle.ts
+++ b/packages/client/src/components/StepByStepNavigation/StepByStepItemStyle.ts
@@ -1,23 +1,7 @@
 import { Icon, breakpoint, themeColor, themeSpacing } from "@amsterdam/asc-ui";
 import styled, { css } from "styled-components";
 
-export type Props = {
-  active?: boolean;
-  checked?: boolean;
-  circleBackgroundColor?: string;
-  clickable?: boolean;
-  customSize?: boolean;
-  disabled?: boolean;
-  disabledTextColor?: string;
-  done?: boolean;
-  doneTextColor?: string;
-  heading?: string;
-  headingProps?: any;
-  highlightActive?: boolean;
-  largeCircle?: boolean;
-  small?: boolean;
-} & React.AnchorHTMLAttributes<HTMLAnchorElement> &
-  React.HTMLAttributes<HTMLDivElement>;
+import { StepByStepItemProps } from "./StepByStepItem";
 
 const circleSize = {
   desktop: {
@@ -30,7 +14,7 @@ const circleSize = {
   },
 };
 
-export default styled.div<Props>`
+export default styled.div<StepByStepItemProps>`
   position: relative;
   display: flex;
   height: 100%;
@@ -82,7 +66,7 @@ export default styled.div<Props>`
     `}
 `;
 
-const CircleWrapperStyle = styled.div<Props>`
+const CircleWrapperStyle = styled.div<StepByStepItemProps>`
   position: relative;
   display: flex;
   width: ${circleSize.mobile.large};
@@ -115,7 +99,7 @@ const CircleWrapperStyle = styled.div<Props>`
   }
 `;
 
-const CircleStyle = styled(Icon)<Props>`
+const CircleStyle = styled(Icon)<StepByStepItemProps>`
   position: relative;
   width: ${circleSize.mobile.large};
   height: ${circleSize.mobile.large};
@@ -159,7 +143,7 @@ const CircleStyle = styled(Icon)<Props>`
     `}
 `;
 
-const ContentWrapperStyle = styled.div<Props>`
+const ContentWrapperStyle = styled.div<StepByStepItemProps>`
   position: relative;
   display: flex;
   max-width: 620px;
@@ -168,7 +152,7 @@ const ContentWrapperStyle = styled.div<Props>`
   justify-content: center;
 `;
 
-const BackgroundStyle = styled.div<Props>`
+const BackgroundStyle = styled.div<StepByStepItemProps>`
   position: absolute;
   height: 100%;
   width: 300vw;

--- a/packages/client/src/components/StepByStepNavigation/StepByStepNavigation.tsx
+++ b/packages/client/src/components/StepByStepNavigation/StepByStepNavigation.tsx
@@ -1,12 +1,20 @@
 import { themeColor } from "@amsterdam/asc-ui";
-import React from "react";
+import React, { FunctionComponent, HTMLAttributes } from "react";
 
 import passPropsToChildren from "../../utils/passPropsToChildren";
 import { STEPBYSTEPNAVIGATION } from "../../utils/test-ids";
-import StepByStepNavigationStyle, { Props } from "./StepByStepNavigationStyle";
+import StepByStepNavigationStyle from "./StepByStepNavigationStyle";
 
-const StepByStepNavigation: React.FC<
-  Props & React.HTMLAttributes<HTMLElement>
+export type StepByStepNavigationProps = {
+  customSize?: boolean;
+  disabledTextColor?: any;
+  doneTextColor?: any;
+  highlightActive?: boolean;
+  lineBetweenItems?: boolean;
+};
+
+const StepByStepNavigation: FunctionComponent<
+  StepByStepNavigationProps & HTMLAttributes<HTMLElement>
 > = ({
   children: childrenProp,
   customSize,
@@ -43,6 +51,6 @@ const StepByStepNavigation: React.FC<
 StepByStepNavigation.defaultProps = {
   disabledTextColor: themeColor("tint", "level5"),
   doneTextColor: themeColor("tint", "level4"),
-} as Props;
+} as StepByStepNavigationProps;
 
 export default StepByStepNavigation;

--- a/packages/client/src/components/StepByStepNavigation/StepByStepNavigationStyle.ts
+++ b/packages/client/src/components/StepByStepNavigation/StepByStepNavigationStyle.ts
@@ -2,16 +2,9 @@ import { themeColor } from "@amsterdam/asc-ui";
 import styled, { css } from "styled-components";
 
 import StepByStepItemStyle, { CircleWrapperStyle } from "./StepByStepItemStyle";
+import { StepByStepNavigationProps } from "./StepByStepNavigation";
 
-export type Props = {
-  customSize?: boolean;
-  disabledTextColor?: any;
-  doneTextColor?: any;
-  highlightActive?: boolean;
-  lineBetweenItems?: boolean;
-};
-
-export default styled.div<Props>`
+export default styled.div<StepByStepNavigationProps>`
   /* Remove the line (going downwards) only from the last Item */
   ${StepByStepItemStyle} {
     ${({ lineBetweenItems }) =>

--- a/packages/client/src/components/StepByStepNavigation/StepByStepTitle.tsx
+++ b/packages/client/src/components/StepByStepNavigation/StepByStepTitle.tsx
@@ -1,15 +1,11 @@
 import { Heading, Paragraph } from "@amsterdam/asc-ui";
-import React from "react";
+import React, { FunctionComponent, HTMLAttributes } from "react";
 
-import { Props } from "./StepByStepItemStyle";
+import { StepByStepItemProps } from "./StepByStepItem";
 
-const StepByStepTitle: React.FC<Props & React.HTMLAttributes<HTMLElement>> = ({
-  children,
-  customSize,
-  heading,
-  headingProps,
-  small,
-}) =>
+const StepByStepTitle: FunctionComponent<
+  StepByStepItemProps & HTMLAttributes<HTMLElement>
+> = ({ children, customSize, heading, headingProps, small }) =>
   small ? (
     <Paragraph
       gutterBottom={children ? 12 : 0}

--- a/packages/client/src/components/Visual.tsx
+++ b/packages/client/src/components/Visual.tsx
@@ -1,5 +1,5 @@
 import { captureException } from "@sentry/browser";
-import React, { useState } from "react";
+import React, { FunctionComponent, useState } from "react";
 
 import { FIGCAPTION, FIGURE, IMG } from "../utils/test-ids";
 import { Caption, Figure, Img } from "./VisualStyles";
@@ -10,7 +10,7 @@ type VisualProps = {
   title?: string;
 };
 
-const Visual: React.FC<VisualProps> = ({ alt, src, title }) => {
+const Visual: FunctionComponent<VisualProps> = ({ alt, src, title }) => {
   const [loaded, setLoaded] = useState(false);
   const [errored, setErrored] = useState(false);
 

--- a/packages/client/src/config/index.test.tsx
+++ b/packages/client/src/config/index.test.tsx
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom/extend-expect";
 
-import React from "react";
+import React, { FunctionComponent } from "react";
 
 import { render } from "../utils/test-utils";
 import { getMatomoSiteId } from "./matomo";
@@ -15,7 +15,7 @@ const tryIntroFile = (intro: string) => {
   }
 };
 
-const AllIntroPages: React.FC = () => (
+const AllIntroPages: FunctionComponent = () => (
   <>
     {topics.map((t) =>
       t.intro ? <p key={t.intro}>{tryIntroFile(t.intro)}</p> : null

--- a/packages/client/src/config/index.ts
+++ b/packages/client/src/config/index.ts
@@ -1,30 +1,3 @@
-type BaseTopic = {
-  name: string;
-  slug: string;
-  text: {
-    heading: string;
-    locationIntro?: string;
-  };
-};
-
-type IMTRTopic = {
-  hasIMTR: true;
-  intro?: string;
-  redirectToOlo?: false;
-} & BaseTopic;
-
-type OloTopic = {
-  hasIMTR: false;
-  intro?: string;
-  redirectToOlo?: false;
-} & BaseTopic;
-
-type RedirectToOloTopic = {
-  hasIMTR: false;
-  redirectToOlo: true;
-  intro?: undefined;
-} & BaseTopic;
-
 /**
  * Merge the different topic types
  *
@@ -35,7 +8,8 @@ type RedirectToOloTopic = {
  * slug: The part of our app URL that identifies which permit-checker to load (`dakraam-plaatsen` will be `https://vergunningcheck.amsterdam.nl/dakraam-plaatsen`)
  * text: This is part that holds specific texts for each permit-checker
  */
-export type Topic = OloTopic | IMTRTopic | RedirectToOloTopic;
+
+import { Topic } from "../types";
 
 type OloUrlProps = {
   houseNumber: number;

--- a/packages/client/src/debug/DebugCheckersTable.tsx
+++ b/packages/client/src/debug/DebugCheckersTable.tsx
@@ -1,7 +1,7 @@
 import { Heading, Paragraph } from "@amsterdam/asc-ui";
 import { themeSpacing } from "@amsterdam/asc-ui";
 import { Button } from "@amsterdam/asc-ui";
-import React from "react";
+import React, { FunctionComponent } from "react";
 import { useState } from "react";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
@@ -68,7 +68,7 @@ const returnedData = (apiTopic: topicProps) => {
   );
 };
 
-const DebugCheckersTable: React.FC = () => {
+const DebugCheckersTable: FunctionComponent = () => {
   const [showChecks, setShowChecks] = useState(false);
 
   return (

--- a/packages/client/src/debug/DebugDecisionTable.tsx
+++ b/packages/client/src/debug/DebugDecisionTable.tsx
@@ -1,11 +1,11 @@
 import { Accordion } from "@amsterdam/asc-ui";
 import { Decision, Permit, Question } from "@vergunningcheck/imtr-client";
-import React from "react";
+import React, { FunctionComponent } from "react";
 
 import HiddenDebugInfo from "../components/HiddenDebugInfo";
 import { useChecker, useTopicData } from "../hooks";
 
-const QuestionSummary: React.FC<{ question: Question }> = ({
+const QuestionSummary: FunctionComponent<{ question: Question }> = ({
   question: { prio, autofill, text },
 }) => (
   <>
@@ -13,7 +13,9 @@ const QuestionSummary: React.FC<{ question: Question }> = ({
   </>
 );
 
-const Answer: React.FC<{ question: Question }> = ({ question: { answer } }) => (
+const Answer: FunctionComponent<{ question: Question }> = ({
+  question: { answer },
+}) => (
   <>
     {answer === null ? (
       "NULL"
@@ -23,7 +25,7 @@ const Answer: React.FC<{ question: Question }> = ({ question: { answer } }) => (
   </>
 );
 
-const DebugDecisionTable: React.FC = () => {
+const DebugDecisionTable: FunctionComponent = () => {
   const { checker } = useChecker();
   const { topicData } = useTopicData();
   const decisionId = "dummy";

--- a/packages/client/src/debug/DebugVariables.tsx
+++ b/packages/client/src/debug/DebugVariables.tsx
@@ -1,5 +1,5 @@
 import { Accordion, Card, CardContent, Heading, Link } from "@amsterdam/asc-ui";
-import React, { useContext } from "react";
+import React, { FunctionComponent, useContext } from "react";
 
 import Permit from "../../../imtr-client/src/models/permit";
 import { CheckerContext } from "../CheckerContext";
@@ -10,7 +10,7 @@ import { Debug } from ".";
 
 type DebugVariablesProps = {};
 
-const DebugVariables: React.FC<DebugVariablesProps> = () => {
+const DebugVariables: FunctionComponent<DebugVariablesProps> = () => {
   const slug = useSlug();
   const topic = useTopic();
   const { session, setSession } = useSession();

--- a/packages/client/src/hooks/__mocks__/useTopic.ts
+++ b/packages/client/src/hooks/__mocks__/useTopic.ts
@@ -1,4 +1,5 @@
-import { Topic, topics } from "../../config";
+import { topics } from "../../config";
+import { Topic } from "../../types";
 
 export default () => {
   return topics.find((topic: Topic) => topic.slug === "dakkapel-plaatsen");

--- a/packages/client/src/intros/DakkapelIntro.tsx
+++ b/packages/client/src/intros/DakkapelIntro.tsx
@@ -1,10 +1,9 @@
-import React from "react";
+import React, { FunctionComponent } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Intro } from "./shared";
-import { IntroProps } from ".";
 
-const DakraamIntro: React.FC<IntroProps> = () => {
+const DakraamIntro: FunctionComponent = () => {
   const { t } = useTranslation();
   return (
     <Intro

--- a/packages/client/src/intros/DakraamIntro.tsx
+++ b/packages/client/src/intros/DakraamIntro.tsx
@@ -1,10 +1,9 @@
-import React from "react";
+import React, { FunctionComponent } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Intro } from "./shared";
-import { IntroProps } from ".";
 
-const DakraamIntro: React.FC<IntroProps> = () => {
+const DakraamIntro: FunctionComponent = () => {
   const { t } = useTranslation();
   return (
     <Intro

--- a/packages/client/src/intros/KozijnenIntro.tsx
+++ b/packages/client/src/intros/KozijnenIntro.tsx
@@ -1,10 +1,9 @@
-import React from "react";
+import React, { FunctionComponent } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Intro } from "./shared";
-import { IntroProps } from ".";
 
-const KozijnenIntro: React.FC<IntroProps> = () => {
+const KozijnenIntro: FunctionComponent = () => {
   const { t } = useTranslation();
   return (
     <Intro

--- a/packages/client/src/intros/ZonnepanelenIntro.tsx
+++ b/packages/client/src/intros/ZonnepanelenIntro.tsx
@@ -1,10 +1,9 @@
-import React from "react";
+import React, { FunctionComponent } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Intro } from "./shared";
-import { IntroProps } from ".";
 
-const ZonnepanelenIntro: React.FC<IntroProps> = () => {
+const ZonnepanelenIntro: FunctionComponent = () => {
   const { t } = useTranslation();
   return (
     <Intro

--- a/packages/client/src/intros/ZonweringRolluikIntro.tsx
+++ b/packages/client/src/intros/ZonweringRolluikIntro.tsx
@@ -1,10 +1,9 @@
-import React from "react";
+import React, { FunctionComponent } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Intro } from "./shared";
-import { IntroProps } from ".";
 
-const ZonweringRolluikIntro: React.FC<IntroProps> = () => {
+const ZonweringRolluikIntro: FunctionComponent = () => {
   const { t } = useTranslation();
   return (
     <Intro

--- a/packages/client/src/intros/index.ts
+++ b/packages/client/src/intros/index.ts
@@ -1,1 +1,0 @@
-export type IntroProps = React.FC;

--- a/packages/client/src/intros/shared/DynamicIMTRIntro.tsx
+++ b/packages/client/src/intros/shared/DynamicIMTRIntro.tsx
@@ -1,12 +1,11 @@
-import React from "react";
+import React, { FunctionComponent } from "react";
 
 import { autofillResolvers } from "../../config/autofill";
 import { useChecker } from "../../hooks";
 import LoadingPage from "../../pages/LoadingPage";
 import { Intro } from ".";
-import { IntroProps } from "..";
 
-const DynamicIMTRIntro: IntroProps = () => {
+const DynamicIMTRIntro: FunctionComponent = () => {
   const { checker } = useChecker();
   if (checker) {
     const dependantOnQuestions = checker._getUpcomingQuestions().length > 0;

--- a/packages/client/src/pages/CheckerPage.tsx
+++ b/packages/client/src/pages/CheckerPage.tsx
@@ -21,11 +21,8 @@ import {
   useTopicData,
   useTracking,
 } from "../hooks";
-import {
-  Address,
-  SessionContext,
-  defaultTopicSession,
-} from "../SessionContext";
+import { SessionContext, defaultTopicSession } from "../SessionContext";
+import { Address } from "../types";
 import { isEmptyObject } from "../utils";
 import ErrorPage from "./ErrorPage";
 import LoadingPage from "./LoadingPage";

--- a/packages/client/src/pages/ErrorPage.tsx
+++ b/packages/client/src/pages/ErrorPage.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { FunctionComponent } from "react";
 import { Helmet } from "react-helmet";
 import { useTranslation } from "react-i18next";
 
@@ -14,7 +14,7 @@ type ErrorPageProps = {
   error?: ErrorProps;
 };
 
-const ErrorPage: React.FC<ErrorPageProps> = ({ error }) => {
+const ErrorPage: FunctionComponent<ErrorPageProps> = ({ error }) => {
   const { t } = useTranslation();
   return (
     <BaseLayout>

--- a/packages/client/src/pages/HomePage.tsx
+++ b/packages/client/src/pages/HomePage.tsx
@@ -1,11 +1,11 @@
 /* istanbul ignore file */
-import React from "react";
+import React, { FunctionComponent } from "react";
 
 import { BaseLayout } from "../components/Layouts";
 import { isProduction } from "../config";
 import { DebugCheckersTable } from "../debug";
 
-const HomePage: React.FC = () => {
+const HomePage: FunctionComponent = () => {
   if (isProduction) {
     localStorage.setItem("doNotTrack", "true");
   }

--- a/packages/client/src/pages/IntroPage.tsx
+++ b/packages/client/src/pages/IntroPage.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense } from "react";
+import React, { FunctionComponent, Suspense, lazy } from "react";
 import { Helmet } from "react-helmet";
 import { useHistory } from "react-router-dom";
 
@@ -6,19 +6,18 @@ import { TopicLayout } from "../components/Layouts";
 import Loading from "../components/Loading";
 import Nav from "../components/Nav";
 import { useTopic } from "../hooks";
-import { IntroProps } from "../intros";
 import { geturl, routes } from "../routes";
 
-const IntroPage: React.FC = () => {
+const IntroPage: FunctionComponent = () => {
   const history = useHistory();
 
   const topic = useTopic();
   const { text, intro } = topic;
 
   const introComponentPath = intro || "shared/DynamicIMTRIntro";
-  const Intro = React.lazy(
+  const Intro = lazy(
     () => import(`../intros/${introComponentPath}`)
-  ) as IntroProps;
+  ) as FunctionComponent;
 
   const goToNext = () => {
     history.push(geturl(routes.checker, topic));

--- a/packages/client/src/pages/LoadingPage.tsx
+++ b/packages/client/src/pages/LoadingPage.tsx
@@ -1,10 +1,10 @@
-import React from "react";
+import React, { FunctionComponent } from "react";
 import { Helmet } from "react-helmet";
 
 import { BaseLayout } from "../components/Layouts";
 import Loading from "../components/Loading";
 
-const LoadingPage: React.FC = () => (
+const LoadingPage: FunctionComponent = () => (
   <BaseLayout disablePageView>
     <Helmet>
       <title>Laden... - Amsterdam Vergunningcheck</title>

--- a/packages/client/src/pages/NotFoundPage.tsx
+++ b/packages/client/src/pages/NotFoundPage.tsx
@@ -1,10 +1,10 @@
 import { Heading, Paragraph } from "@amsterdam/asc-ui";
-import React from "react";
+import React, { FunctionComponent } from "react";
 import { Helmet } from "react-helmet";
 
 import { BaseLayout } from "../components/Layouts";
 
-const NotFoundPage: React.FC = () => (
+const NotFoundPage: FunctionComponent = () => (
   <BaseLayout>
     <Helmet>
       <title>Pagina niet gevonden - Amsterdam Vergunningcheck</title>

--- a/packages/client/src/pages/olo/OloLocationInput.tsx
+++ b/packages/client/src/pages/olo/OloLocationInput.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense } from "react";
+import React, { FunctionComponent, Suspense } from "react";
 import { Helmet } from "react-helmet";
 import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";
@@ -9,7 +9,7 @@ import { LocationInput } from "../../components/Location/";
 import { useTopic } from "../../hooks";
 import { geturl, routes } from "../../routes";
 
-const OloLocationInput: React.FC = () => {
+const OloLocationInput: FunctionComponent = () => {
   const topic = useTopic();
   const history = useHistory();
   const { t } = useTranslation();

--- a/packages/client/src/pages/olo/OloLocationResult.tsx
+++ b/packages/client/src/pages/olo/OloLocationResult.tsx
@@ -1,5 +1,5 @@
 import { Heading, Paragraph } from "@amsterdam/asc-ui";
-import React, { Suspense } from "react";
+import React, { FormEvent, FunctionComponent, Suspense } from "react";
 import { Helmet } from "react-helmet";
 import { useHistory } from "react-router-dom";
 
@@ -14,7 +14,7 @@ import { useTopic, useTopicData, useTracking } from "../../hooks";
 import { geturl, routes } from "../../routes";
 import { LOCATION_RESULT } from "../../utils/test-ids";
 
-const OloLocationResult: React.FC = () => {
+const OloLocationResult: FunctionComponent = () => {
   const topic = useTopic();
   const history = useHistory();
   const { topicData } = useTopicData();
@@ -29,7 +29,7 @@ const OloLocationResult: React.FC = () => {
     return null;
   }
 
-  const onSubmit = (e: React.FormEvent) => {
+  const onSubmit = (e: FormEvent) => {
     e.preventDefault();
     matomoTrackEvent({
       action: actions.CLICK_EXTERNAL_NAVIGATION,

--- a/packages/client/src/pages/olo/OloRedirectPage.tsx
+++ b/packages/client/src/pages/olo/OloRedirectPage.tsx
@@ -1,12 +1,12 @@
 import { Heading, Paragraph } from "@amsterdam/asc-ui";
-import React, { useEffect } from "react";
+import React, { FunctionComponent, useEffect } from "react";
 import { Helmet } from "react-helmet";
 
 import { TopicLayout } from "../../components/Layouts";
 import { urls } from "../../config";
 import { useTopic } from "../../hooks";
 
-const OloRedirectPage: React.FC = () => {
+const OloRedirectPage: FunctionComponent = () => {
   const topic = useTopic();
 
   useEffect(() => {

--- a/packages/client/src/routes.ts
+++ b/packages/client/src/routes.ts
@@ -1,5 +1,5 @@
 import { reverse } from "named-urls";
-import React from "react";
+import { lazy } from "react";
 import { RouteProps } from "react-router-dom";
 import slugify from "slugify";
 
@@ -44,20 +44,20 @@ const baseRouteConfig: RoutePropExtended[] = [
   {
     component:
       process.env.NODE_ENV !== "production"
-        ? React.lazy(() => import(`./pages/HomePage`))
+        ? lazy(() => import(`./pages/HomePage`))
         : undefined,
     exact: true,
     name: "home",
     path: "/",
   },
   {
-    component: React.lazy(() => import(`./pages/HomePage`)),
+    component: lazy(() => import(`./pages/HomePage`)),
     exact: true,
     path: "/test",
     name: "test",
   },
   {
-    component: React.lazy(
+    component: lazy(
       () => import(/* webpackPrefetch: true */ `./pages/IntroPage`)
     ),
     name: "intro",
@@ -65,7 +65,7 @@ const baseRouteConfig: RoutePropExtended[] = [
     path: `/:slug(${imtrSlugs})`,
   },
   {
-    component: React.lazy(
+    component: lazy(
       () => import(/* webpackPrefetch: true */ `./pages/CheckerPage`)
     ),
     exact: true,
@@ -73,7 +73,7 @@ const baseRouteConfig: RoutePropExtended[] = [
     path: `/:slug(${imtrSlugs})/vragen-en-uitkomst`,
   },
   {
-    component: React.lazy(
+    component: lazy(
       () => import(/* webpackPrefetch: true */ `./pages/olo/OloLocationInput`)
     ),
     exact: true,
@@ -81,7 +81,7 @@ const baseRouteConfig: RoutePropExtended[] = [
     path: `/:slug(${oloSlugs})`,
   },
   {
-    component: React.lazy(
+    component: lazy(
       () => import(/* webpackPrefetch: true */ `./pages/olo/OloLocationResult`)
     ),
     exact: true,
@@ -89,7 +89,7 @@ const baseRouteConfig: RoutePropExtended[] = [
     path: `/:slug(${oloSlugs})/adresgegevens`,
   },
   {
-    component: React.lazy(
+    component: lazy(
       () => import(/* webpackPrefetch: true */ `./pages/olo/OloRedirectPage`)
     ),
     exact: true,
@@ -97,7 +97,7 @@ const baseRouteConfig: RoutePropExtended[] = [
     path: `/:slug(${oloRedirectSlugs})`,
   },
   {
-    component: React.lazy(() => import("./pages/NotFoundPage")),
+    component: lazy(() => import("./pages/NotFoundPage")),
     name: "notfound",
     path: "*",
   },

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -1,0 +1,98 @@
+import { Answer } from "@vergunningcheck/imtr-client";
+
+/**
+ * Location types
+ */
+export type Restriction = {
+  __typename?: string;
+  name?: string;
+  scope?: string;
+};
+
+export type ZoningPlan = {
+  __typename?: string;
+  name?: string;
+  scope?: string;
+};
+
+export type AddressType = {
+  __typename?: string;
+  districtName: string;
+  houseNumber: number;
+  houseNumberFull: string;
+  id: string;
+  neighborhoodName: string;
+  postalCode: string;
+  residence: string;
+  restrictions: Restriction[];
+  streetName: string;
+  zoningPlans: ZoningPlan[];
+};
+
+export type Address = null | AddressType;
+
+/**
+ * Context and session types
+ */
+export type TopicData = {
+  activeComponents?: string[];
+  address: Address;
+  answers: {
+    [id: string]: Answer;
+  };
+  finishedComponents: string[];
+  type: string;
+  questionIndex: number;
+};
+
+export type setTopicFn = (topicData: Partial<TopicData>) => void;
+export type setSessionFn = (sessionData: Partial<SessionData>) => void;
+
+export type SessionData = {
+  [slug: string]: null | TopicData;
+};
+
+export type setTopicSessionDataFn = (
+  topicData: null | Partial<TopicData>
+) => void;
+
+/**
+ * Topic types
+ */
+type BaseTopic = {
+  name: string;
+  slug: string;
+  text: {
+    heading: string;
+    locationIntro?: string;
+  };
+};
+
+type IMTRTopic = {
+  hasIMTR: true;
+  intro?: string;
+  redirectToOlo?: false;
+} & BaseTopic;
+
+type OloTopic = {
+  hasIMTR: false;
+  intro?: string;
+  redirectToOlo?: false;
+} & BaseTopic;
+
+type RedirectToOloTopic = {
+  hasIMTR: false;
+  redirectToOlo: true;
+  intro?: undefined;
+} & BaseTopic;
+
+export type Topic = OloTopic | IMTRTopic | RedirectToOloTopic;
+
+/**
+ * Checker related types
+ */
+export type BooleanOption = {
+  formValue: string;
+  label: string;
+  value: boolean;
+};

--- a/packages/client/src/utils/index.ts
+++ b/packages/client/src/utils/index.ts
@@ -1,9 +1,10 @@
+import { MutableRefObject } from "react";
 import { matchPath } from "react-router";
 
-import { Topic, topics } from "../config";
+import { topics } from "../config";
 import { imtrSlugs, oloRedirectSlugs, oloSlugs } from "../routes";
-import { Restriction } from "../SessionContext";
 import topicsJson from "../topics.json";
+import { Restriction, Topic } from "../types";
 
 // Get slug from url
 export const getSlugFromPathname = (pathname: string) => {
@@ -60,11 +61,11 @@ export const isEmptyObject = (obj: object) =>
  * Scroll to `ref` in page. This function calculates the distance between
  * the top of the window and the top of the element and scrolls to it.
  *
- * @param {object} ref - reference to an element created by React.useRef()
+ * @param {object} ref - reference to an element created by useRef()
  * @param {number} offset - pass an offset to reduce from the total distance
  */
 export const scrollToRef = (
-  ref: React.MutableRefObject<HTMLAnchorElement>,
+  ref: MutableRefObject<HTMLAnchorElement>,
   offset: number = 0
 ) =>
   ref &&

--- a/packages/client/src/utils/passPropsToChildren.ts
+++ b/packages/client/src/utils/passPropsToChildren.ts
@@ -1,4 +1,10 @@
-import React, { Children } from "react";
+import {
+  Children,
+  PropsWithoutRef,
+  ReactElement,
+  ReactNode,
+  cloneElement,
+} from "react";
 
 type Callback = (index?: number) => any;
 
@@ -8,12 +14,12 @@ type Callback = (index?: number) => any;
  * @param propsOrCallback this could be an object or a callback with the index as a parameter
  */
 const passPropsToChildren = (
-  childrenProp: React.ReactNode,
-  propsOrCallback: React.PropsWithoutRef<{}> | Callback
+  childrenProp: ReactNode,
+  propsOrCallback: PropsWithoutRef<{}> | Callback
 ) => {
   const children = Children.map(childrenProp, (child, index) =>
-    React.cloneElement(
-      child as React.ReactElement<any>,
+    cloneElement(
+      child as ReactElement<any>,
       typeof propsOrCallback === "function"
         ? propsOrCallback(index)
         : propsOrCallback

--- a/packages/client/src/utils/test-utils.tsx
+++ b/packages/client/src/utils/test-utils.tsx
@@ -6,7 +6,7 @@ import { MockLink, MockedResponse } from "@apollo/client/testing";
 import { MatomoProvider, createInstance } from "@datapunt/matomo-tracker-react";
 import { render as reactRender } from "@testing-library/react";
 import dotenv from "dotenv-flow";
-import React from "react";
+import React, { FunctionComponent } from "react";
 import { BrowserRouter } from "react-router-dom";
 
 import matchMedia from "../__mocks__/matchMedia";
@@ -73,7 +73,7 @@ type TestProviderProps = {
   mocks: readonly MockedResponse<Record<string, any>>[];
 };
 
-const TestProvider: React.FC<TestProviderProps> = ({
+const TestProvider: FunctionComponent<TestProviderProps> = ({
   children,
   mocks = [],
 }) => (
@@ -106,7 +106,7 @@ export const render = (
   mocks?: readonly MockedResponse<Record<string, any>>[]
 ) => {
   // Added new Component to be able to pass the `mocks` prop
-  const WrapperWithMocks: React.FC = ({ children }) => (
+  const WrapperWithMocks: FunctionComponent = ({ children }) => (
     <TestProvider mocks={mocks ? mocks : []}>{children}</TestProvider>
   );
   return reactRender(ui, { wrapper: WrapperWithMocks, ...options });

--- a/packages/imtr-client/src/models/checker.ts
+++ b/packages/imtr-client/src/models/checker.ts
@@ -47,7 +47,7 @@ export default class Checker {
 
   /**
    * Returns a list of questionIds with the given answers.
-   * Useful to store in React.Context or in sessionStorage
+   * Useful to store in Context or in sessionStorage
    *
    * @returns {({string: boolean|string|number|[string]})}  - a list of answers
    */

--- a/pocs/react-hooks/src/App.tsx
+++ b/pocs/react-hooks/src/App.tsx
@@ -1,4 +1,10 @@
-import React, { createContext, useContext, useEffect, useReducer } from "react";
+import React, {
+  createContext,
+  FunctionComponent,
+  useContext,
+  useEffect,
+  useReducer,
+} from "react";
 
 // - Context is needed to update everything at once
 // - Reducer is needed so we can call hooks multiple times in 1 render pass
@@ -116,7 +122,7 @@ export const sessionReducer = (
   } as SessionData;
 };
 
-const SessionProvider: React.FC = ({ children }) => {
+const SessionProvider: FunctionComponent = ({ children }) => {
   // We use the reducer to take care of too complex logic for setState.
   // Because we sometimes need to clear the sessionStorage.
   const [session, setSession] = useReducer(sessionReducer, defaultSession);

--- a/pocs/react-hooks/src/index.js
+++ b/pocs/react-hooks/src/index.js
@@ -1,10 +1,10 @@
-import React from "react";
+import React, { StrictMode } from "react";
 import ReactDOM from "react-dom";
 import App from "./App";
 
 ReactDOM.render(
-  <React.StrictMode>
+  <StrictMode>
     <App />
-  </React.StrictMode>,
+  </StrictMode>,
   document.getElementById("root")
 );


### PR DESCRIPTION
I've placed all the types in a new `types` file and replaced all `React.[something]` imports to `import { something } from react` to prepare for React 17. Functionally nothing changed.

(Please merge after two reviews)