### PR TITLE
Created link for new checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,17 +3,22 @@
 All notable changes to this project will be documented in this file.
 
 ## [2.4.2] (2020-12-16)
+
 #### New Features
-* `client`, `imtr-client`, `imtr`
-  * [#696](https://github.com/Amsterdam/vergunningcheck/pull/696) Checker "demolition" with new outcomes and ordering ([@robinpiets](https://github.com/robinpiets))
+
+- `client`, `imtr-client`, `imtr`
+  - [#696](https://github.com/Amsterdam/vergunningcheck/pull/696) Checker "demolition" with new outcomes and ordering ([@robinpiets](https://github.com/robinpiets))
 
 #### Bug fixes
-* `client`
-  * [#728](https://github.com/Amsterdam/vergunningcheck/pull/728) Bugs: Incorrect loading state and incorrect alert show.  ([@svenjens](https://github.com/svenjens))
+
+- `client`
+  - [#728](https://github.com/Amsterdam/vergunningcheck/pull/728) Bugs: Incorrect loading state and incorrect alert show. ([@svenjens](https://github.com/svenjens))
 
 #### Chores
-* `client`
-  * [#701](https://github.com/Amsterdam/vergunningcheck/pull/701) Added intro text translations to tests ([@svenjens](https://github.com/svenjens))
+
+- `client`
+  - [#701](https://github.com/Amsterdam/vergunningcheck/pull/701) Added intro text translations to tests ([@svenjens](https://github.com/svenjens))
+  - [#773](https://github.com/Amsterdam/vergunningcheck/pull/773) Created link for new checker ([@robinpiets](https://github.com/robinpiets))
 
 ## [2.4.1] (2020-11-25)
 

--- a/packages/client/src/config/index.ts
+++ b/packages/client/src/config/index.ts
@@ -162,4 +162,13 @@ export const topics: Topic[] = [
       heading: "Vergunningcheck kappen of snoeien",
     },
   },
+  {
+    hasIMTR: false,
+    name: "Brandveilig gebruik",
+    redirectToOlo: true,
+    slug: "brandveilig-gebruik",
+    text: {
+      heading: "Vergunningcheck brandveilig gebruik",
+    },
+  },
 ];


### PR DESCRIPTION
The new checker "Brandveilig gebruik" needs an URL so our team can create a content accordion on [our "homepage"](https://www.amsterdam.nl/veelgevraagd/?productid=%7BF739272F-F234-4475-B7EC-31DB44365F96%7D)

Since we have some technical releases pending on staging, I'm doing this directly on master.

[Direct link (Netlify)](https://6005a9266faa7e000706bfe5--vergunningcheck.netlify.app/brandveilig-gebruik)

Todo:
- add this hotfix to release notes