### PR TITLE
Prevent a bug when refreshing a checker without getDataNeed

### DIFF
--- a/packages/client/src/components/Question/QuestionSection.tsx
+++ b/packages/client/src/components/Question/QuestionSection.tsx
@@ -1,6 +1,7 @@
 import React, { FunctionComponent, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 
+import { getDataNeed } from "../../config/autofill";
 import { actions, sections } from "../../config/matomo";
 import { useChecker, useSlug, useTopicData, useTracking } from "../../hooks";
 import { SectionComponent } from "../../types";
@@ -78,6 +79,16 @@ const QuestionSection: FunctionComponent<SectionComponent> = (props) => {
   // Skip the Question Section when it has no questions to render
   if (!checker || hideQuestionSection) {
     return null;
+  }
+
+  // Prevent a bug when refreshing a checker without getDataNeed (only happens when first question remains unanswered)
+  if (
+    !getDataNeed(checker) &&
+    isActive &&
+    !isCompleted &&
+    checker.stack.length === 0
+  ) {
+    checker.next();
   }
 
   const saveAnswerHook = () => {

--- a/packages/client/src/components/Question/QuestionSection.tsx
+++ b/packages/client/src/components/Question/QuestionSection.tsx
@@ -81,13 +81,14 @@ const QuestionSection: FunctionComponent<SectionComponent> = (props) => {
     return null;
   }
 
-  // Prevent a bug when refreshing a checker without getDataNeed (only happens when first question remains unanswered)
-  if (
+  const noDataNeedAndEmptyStack =
     !getDataNeed(checker) &&
     isActive &&
     !isCompleted &&
-    checker.stack.length === 0
-  ) {
+    checker.stack.length === 0;
+
+  // Prevent a bug when refreshing a checker without getDataNeed (only happens when first question remains unanswered)
+  if (noDataNeedAndEmptyStack) {
     checker.next();
   }
 

--- a/packages/client/src/components/Question/QuestionSection.tsx
+++ b/packages/client/src/components/Question/QuestionSection.tsx
@@ -87,7 +87,7 @@ const QuestionSection: FunctionComponent<SectionComponent> = (props) => {
     !isCompleted &&
     checker.stack.length === 0;
 
-  // Prevent a bug when refreshing a checker without getDataNeed (only happens when first question remains unanswered)
+  // Prevent an empty Question Section when refreshing a checker without getDataNeed (only happens when first question remains unanswered)
   if (noDataNeedAndEmptyStack) {
     checker.next();
   }


### PR DESCRIPTION
PR #805 is now causing a bug for checkers without data-need [Brandveilig gebruik]: when refreshing without answering the first question, the question section is empty. This PR fixes that bug.

**Reproduce bug:**
1. Go to this [check](https://develop.chappie2.com/brandveilig-gebruik/vragen-en-uitkomst) on the develop branch
2. Refresh the page (without answering the first question)
3. The question section is completely empty

![image](https://user-images.githubusercontent.com/7781865/108208248-14b5f900-7129-11eb-8298-cf5b95ce6e78.png)
