### PR TITLE
Fixed bug with 'in procedure monument' addresses

### DIFF
--- a/packages/client/src/__mocks__/addressMockInProcedureMonument.ts
+++ b/packages/client/src/__mocks__/addressMockInProcedureMonument.ts
@@ -1,0 +1,24 @@
+import { AddressType } from "../types";
+
+export default {
+  districtName: "mock",
+  houseNumberFull: "123",
+  houseNumber: 123,
+  id: "mock",
+  neighborhoodName: "mock",
+  postalCode: "1234 AB",
+  residence: "Amsterdam",
+  restrictions: [
+    {
+      __typename: "Monument",
+      name: "In procedure Gemeentelijk Monument",
+      scope: "MUNICIPAL",
+    },
+  ],
+  streetName: "streetname",
+  zoningPlans: [
+    {
+      name: "zoningplan",
+    },
+  ],
+} as AddressType;

--- a/packages/client/src/config/autofill.test.ts
+++ b/packages/client/src/config/autofill.test.ts
@@ -11,6 +11,7 @@ import {
 } from "@vergunningcheck/imtr-client";
 
 import addressMock from "../__mocks__/addressMock";
+import addressMockInProcedureMonument from "../__mocks__/addressMockInProcedureMonument";
 import addressMockNoCityScape from "../__mocks__/addressMockNoCityScape";
 import addressMockNoMonument from "../__mocks__/addressMockNoMonument";
 import mockedCheckerAutofill from "../__mocks__/checker-autofill-only.json";
@@ -216,6 +217,14 @@ describe("Autofill", () => {
           booleanQuestion
         )
       ).toEqual(addQuotes(monumentAnswers["undefined"]));
+
+      // `In procedure` monument should also map correctly
+      expect(
+        monumentOnAddress(
+          { address: addressMockInProcedureMonument } as AutofillData,
+          booleanQuestion
+        )
+      ).toEqual(addQuotes(monumentAnswers[monumentScope]));
     });
 
     test("monumentBoolean", () => {
@@ -232,6 +241,6 @@ describe("Autofill", () => {
     const hash = await hashFromFile(path.join(__dirname, "autofill.ts"));
 
     // IF THIS TEST FAILS; update the docs first https://docs.google.com/spreadsheets/d/12ZmbRyWoeLiQe50MqlfPNx9ta6jkQD0SK42afnDlnDU/edit?usp=sharing then update the snapshot
-    expect(hash).toMatchInlineSnapshot(`"065af60a83f98894026b301bfdde104f"`);
+    expect(hash).toMatchInlineSnapshot(`"79466c114b6f1718bd62e8d46de8ecb6"`);
   });
 });

--- a/packages/client/src/config/autofill.test.ts
+++ b/packages/client/src/config/autofill.test.ts
@@ -104,6 +104,14 @@ describe("Autofill", () => {
         ._getAllQuestions()
         .find((q) => q.autofill === "monumentList") as Question;
 
+      // Expect mock to contain a "In procedure monument" with correct scope
+      expect(
+        addressMockInProcedureMonument.restrictions.find(
+          ({ name }) => name === "In procedure Gemeentelijk Monument"
+        )?.scope
+      ).toEqual("MUNICIPAL");
+
+      // Expect "In procedure monument" to be mapped as MUNICIPAL monument
       expect(monumentQuestion.answer).toBe('"Gemeentelijk monument"');
     });
 

--- a/packages/client/src/config/autofill.test.ts
+++ b/packages/client/src/config/autofill.test.ts
@@ -91,6 +91,22 @@ describe("Autofill", () => {
       );
     });
 
+    test("with in procedure monument in monumentList", () => {
+      const checker = getChecker(mockedChecker1);
+      expect(checker.stack).toEqual([]);
+      expect(checker._getAllQuestions()[0].answer).toEqual(undefined);
+
+      checker.autofill(autofillResolvers, {
+        address: addressMockInProcedureMonument,
+      });
+
+      const monumentQuestion = checker
+        ._getAllQuestions()
+        .find((q) => q.autofill === "monumentList") as Question;
+
+      expect(monumentQuestion.answer).toBe('"Gemeentelijk monument"');
+    });
+
     test("without address", () => {
       const checker = getChecker(mockedChecker1);
       expect(checker.stack).toEqual([]);

--- a/packages/client/src/config/autofill.ts
+++ b/packages/client/src/config/autofill.ts
@@ -80,7 +80,14 @@ export const autofillResolvers: AutofillResolverMap = {
         "Monument"
       );
       if (monumentData?.name) {
-        return addQuotes(monumentData.name);
+        // We decided that `in procedure monuments` should be mapped to actual monuments
+        const monument = monumentData.name
+          .replace(
+            "In procedure Gemeentelijk Monument",
+            "Gemeentelijk monument"
+          )
+          .replace("In procedure Rijksmonument", "Rijksmonument");
+        return addQuotes(monument);
       }
     }
     return addQuotes(strings.NO_MONUMENT);


### PR DESCRIPTION
Addresses that have 'in procedure monument' as restriction name were not mapped correctly at the `monumentList` question. We received an error on Sentry and I noticed that the checker was getting stuck in those cases. This PR takes care of this.

To verify this issue is solved: run the `dakkapel` checker with the address listed in [this card](https://trello.com/c/mSN6tID4/2282-fix-bug-in-in-procedure-monument)