### PR TITLE
Extend keyboard functionality within the app

### DIFF
--- a/packages/client/src/components/Outcome/NewCheckerModal.tsx
+++ b/packages/client/src/components/Outcome/NewCheckerModal.tsx
@@ -1,5 +1,10 @@
 import { Paragraph, Radio, RadioGroup } from "@amsterdam/asc-ui";
-import React, { FunctionComponent, useContext, useState } from "react";
+import React, {
+  FunctionComponent,
+  KeyboardEventHandler,
+  useContext,
+  useState,
+} from "react";
 import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";
 
@@ -76,6 +81,13 @@ const NewCheckerModal: FunctionComponent = () => {
     setChecker(undefined);
   };
 
+  const handleKeyDown: KeyboardEventHandler<HTMLInputElement> = (event) => {
+    // Enable 'Enter' key to handle the confirmation
+    if (event.key === "Enter") {
+      handleConfirmButton();
+    }
+  };
+
   return (
     <Modal
       closeButtonText={t("common.cancel")}
@@ -105,6 +117,7 @@ const NewCheckerModal: FunctionComponent = () => {
                     onChange={() => {
                       setCheckerSlug(slug);
                     }}
+                    onKeyDown={handleKeyDown}
                   />
                 </Label>
               ))}

--- a/packages/client/src/components/StepByStepNavigation/StepByStepItem.tsx
+++ b/packages/client/src/components/StepByStepNavigation/StepByStepItem.tsx
@@ -3,6 +3,7 @@ import React, {
   AnchorHTMLAttributes,
   FunctionComponent,
   HTMLAttributes,
+  KeyboardEventHandler,
   MouseEvent,
 } from "react";
 import { StyledProps } from "styled-components";
@@ -70,9 +71,15 @@ const StepByStepItem: FunctionComponent<
   // All "inactive" items are `small` by default, except when `customSize` has been set
   const small = (!customSize && !active) || (customSize && !largeCircle);
 
-  // @TODO: also enable the ENTER key to act as onClick
   const handleOnClick = (event: MouseEvent<HTMLElement, MouseEvent>) => {
     onClick && onClick(event);
+  };
+
+  const handleKeyDown: KeyboardEventHandler<HTMLElement> = (event) => {
+    // Enable 'Enter' key to handle the onClick function
+    if (event.key === "Enter") {
+      onClick && onClick(event);
+    }
   };
 
   return (
@@ -93,6 +100,7 @@ const StepByStepItem: FunctionComponent<
       aria-label={clickable ? heading : ""}
       as={clickable ? "a" : "div"}
       onClick={handleOnClick}
+      onKeyDown={handleKeyDown}
       role="menuitem"
       tabIndex={clickable && !disabled && !active ? 0 : -1}
       {...otherProps}


### PR DESCRIPTION
#### This feature adds support for keyboard control on the StepByStepItem (to navigate to an inactive section) and on the NewCheckerModal (to handle confirmation)

---

To test the StepByStepItem, go to the outcome section, edit a question and navigate with Tab to the outcome section and press Enter. Expected behaviour: it activates the outcome section

<img src=https://user-images.githubusercontent.com/7781865/111469296-d0694900-8726-11eb-9ac5-d8b049a2d267.png width=500 />
